### PR TITLE
TweakDB and some other small things

### DIFF
--- a/include/RED4ext/Addresses.hpp
+++ b/include/RED4ext/Addresses.hpp
@@ -53,4 +53,8 @@ constexpr uintptr_t Handle_DecWeakRef = 0x1401C1020 - ImageBase; // 40 53 48 83 
 #pragma region IScriptable
 constexpr uintptr_t IScriptable_GetValueHolder = 0x1401FDDD0 - ImageBase; // 40 53 48 83 EC 20 48 83 79 38 00, expected: 4, index: 1
 #pragma endregion
+
+#pragma region TweakDB
+constexpr uintptr_t TweakDB_Get = 0x140C01330 - ImageBase; // 48 83 EC 48 48 8B 05 ? ? ? ? 48 85 C0 0F 85 8A 00 00 00, expected: 1, index: 0
+#pragma endregion
 } // namespace RED4ext::Addresses

--- a/include/RED4ext/DynArray.hpp
+++ b/include/RED4ext/DynArray.hpp
@@ -18,6 +18,26 @@ struct DynArray
         return entries[aIndex];
     }
 
+    T* begin()
+    {
+        return entries;
+    }
+
+    const T* begin() const
+    {
+        return entries;
+    }
+
+    T* end()
+    {
+        return entries + size;
+    }
+
+    const T* end() const
+    {
+        return entries + size;
+    }
+
     T*       entries;   // 00
     uint32_t capacity;  // 08
     uint32_t size;      // 0C

--- a/include/RED4ext/DynArray.hpp
+++ b/include/RED4ext/DynArray.hpp
@@ -18,24 +18,44 @@ struct DynArray
         return entries[aIndex];
     }
 
-    T* begin()
+    T* Begin()
     {
         return entries;
+    }
+
+    const T* Begin() const
+    {
+        return entries;
+    }
+
+    T* begin()
+    {
+        return Begin();
     }
 
     const T* begin() const
     {
-        return entries;
+        return Begin();
+    }
+
+    T* End()
+    {
+        return entries + size;
+    }
+
+    const T* End() const
+    {
+        return entries + size;
     }
 
     T* end()
     {
-        return entries + size;
+        return End();
     }
 
     const T* end() const
     {
-        return entries + size;
+        return End();
     }
 
     T*       entries;   // 00

--- a/include/RED4ext/GameEngine.hpp
+++ b/include/RED4ext/GameEngine.hpp
@@ -87,11 +87,10 @@ struct GameInstance
     virtual void Unk_60() = 0;
     virtual void Unk_68() = 0;
 
-    HashMapBase<IRTTIType*, Handle<IScriptable>> unk08; // 08
-    uintptr_t unk30;                                    // 30
-    DynArray<Handle<IScriptable>> unk38;                // 38
-    HashMapBase<uintptr_t, void*> unk40;                // 40
-    uintptr_t unk70[(0x138 - 0x70) >> 3];               // 70
+    HashMap<IRTTIType*, Handle<IScriptable>> unk08; // 08
+    DynArray<Handle<IScriptable>> unk38;            // 38
+    HashMap<uintptr_t, void*> unk40;                // 40
+    uintptr_t unk78[(0x138 - 0x78) >> 3];           // 78
 };
 RED4EXT_ASSERT_SIZE(GameInstance, 0x138);
 

--- a/include/RED4ext/REDhash.hpp
+++ b/include/RED4ext/REDhash.hpp
@@ -21,30 +21,30 @@ constexpr uint64_t FNV1a(const char* aText)
     return hash;
 }
 
-constexpr uint32_t FNV1a32(const uint8_t* data, const size_t len)
+constexpr uint32_t FNV1a32(const uint8_t* aData, const size_t aLen)
 {
     constexpr uint32_t basis = 0x811c9dc5;
     constexpr uint32_t prime = 0x01000193;
 
     uint32_t hash = basis;
-    for (size_t i = 0; i != len; ++i)
+    for (size_t i = 0; i != aLen; ++i)
     {
-        hash ^= data[i];
+        hash ^= aData[i];
         hash *= prime;
     }
 
     return hash;
 }
 
-constexpr uint64_t FNV1a64(const uint8_t* data, const size_t len)
+constexpr uint64_t FNV1a64(const uint8_t* aData, const size_t aLen)
 {
     constexpr uint64_t basis = 0xCBF29CE484222325;
     constexpr uint64_t prime = 0x100000001b3;
 
     uint64_t hash = basis;
-    for (size_t i = 0; i != len; ++i)
+    for (size_t i = 0; i != aLen; ++i)
     {
-        hash ^= data[i];
+        hash ^= aData[i];
         hash *= prime;
     }
 

--- a/include/RED4ext/REDhash.hpp
+++ b/include/RED4ext/REDhash.hpp
@@ -20,4 +20,34 @@ constexpr uint64_t FNV1a(const char* aText)
 
     return hash;
 }
+
+constexpr uint32_t FNV1a32(const uint8_t* data, const size_t len)
+{
+    constexpr uint32_t basis = 0x811c9dc5;
+    constexpr uint32_t prime = 0x01000193;
+
+    uint32_t hash = basis;
+    for (size_t i = 0; i != len; ++i)
+    {
+        hash ^= data[i];
+        hash *= prime;
+    }
+
+    return hash;
+}
+
+constexpr uint64_t FNV1a64(const uint8_t* data, const size_t len)
+{
+    constexpr uint64_t basis = 0xCBF29CE484222325;
+    constexpr uint64_t prime = 0x100000001b3;
+
+    uint64_t hash = basis;
+    for (size_t i = 0; i != len; ++i)
+    {
+        hash ^= data[i];
+        hash *= prime;
+    }
+
+    return hash;
+}
 } // namespace RED4ext

--- a/include/RED4ext/RTTISystem.hpp
+++ b/include/RED4ext/RTTISystem.hpp
@@ -57,18 +57,16 @@ struct CRTTISystem : IRTTISystem
     static CRTTISystem* Get();
 
     uint64_t unk08;                          // 08
-    HashMapBase<CName, IRTTIType*> types;    // 10
-    HashMap<uint64_t, IRTTIType*> typeByIds; // 38
-    HashMap<CName, uint64_t> typeIds;        // 68
-    HashMap<CName, CGlobalFunction*> funcs;  // 98
-    HashMap<CName, CBaseFunction*> unkC8;    // C8
-    HashMap<CName, CName> unkF8;             // F8
-    int64_t unk128;                          // 128
+    HashMap<CName, IRTTIType*> types;        // 10
+    HashMap<uint64_t, IRTTIType*> typeByIds; // 40
+    HashMap<CName, uint64_t> typeIds;        // 70
+    HashMap<CName, CGlobalFunction*> funcs;  // A0
+    HashMap<CName, CBaseFunction*> unkC8;    // D0
+    HashMap<CName, CName> unkF8;             // 100
     DynArray<void*> unk130;                  // 130
     DynArray<void*> unk140;                  // 140
-    HashMapBase<CName, CName> scriptToNative; // 150
-    HashMap<CName, CName> nativeToScript;    // 178
-    int64_t unk1A8;                          // 1A8
+    HashMap<CName, CName> scriptToNative;    // 150
+    HashMap<CName, CName> nativeToScript;    // 180
     DynArray<void*> unk1B0;                  // 1B0
     DynArray<void*> unk1C0;                  // 1C0
     CRITICAL_SECTION unk1D0;                 // 1D0

--- a/include/RED4ext/RTTITypes.hpp
+++ b/include/RED4ext/RTTITypes.hpp
@@ -238,11 +238,11 @@ struct CClass : CRTTIType
     int64_t unk90;                            // 90
     int32_t unk98;                            // 98
     int32_t unk9C;                            // 9C
-    HashMap<uint64_t, CClassFunction*> unkA0; // A0
-    int64_t unkD0;                            // D0
+    int64_t unkA0;                            // A0
+    HashMap<uint64_t, CClassFunction*> unkA8; // A8
     int64_t unkD8;                            // D8
-    HashMap<uint64_t, CRTTIType*> unkE0;      // E0
-    int64_t unk110;                           // 110
+    int64_t unkE0;                            // E0
+    HashMap<uint64_t, CRTTIType*> unkE8;      // E8
     DynArray<CProperty*> unk118;              // 118 More entries than 0x28, will contain native props
     DynArray<void*> unk128;                   // 128
     DynArray<CProperty*> unk138;              // 138 Only RT_Class types?

--- a/include/RED4ext/Types/CharacterCustomization.hpp
+++ b/include/RED4ext/Types/CharacterCustomization.hpp
@@ -97,8 +97,8 @@ struct CGameuiCharacterCustomizationSystem : IScriptable
     DynArray<void*> unk128;                                                        // 128
     DynArray<void*> unk138;                                                        // 138
     DynArray<void*> unk148;                                                        // 148
-    HashMapBase<uint64_t, uint64_t> unk158;                                        // 158
-    uintptr_t unk180[(0x1B8 - 0x180) >> 3];                                        // 180
+    HashMap<uint64_t, uint64_t> unk158;                                            // 158
+    uintptr_t unk188[(0x1B8 - 0x188) >> 3];                                        // 188
     DynArray<void*> unk1B8;                                                        // 1B8
     DynArray<void*> unk1C8;                                                        // 1C8
     uintptr_t unk1D8;                                                              // 1D8

--- a/include/RED4ext/Types/SharedMutex-inl.hpp
+++ b/include/RED4ext/Types/SharedMutex-inl.hpp
@@ -6,7 +6,7 @@
 
 RED4EXT_INLINE bool RED4ext::SharedMutex::try_lock()
 {
-    return _InterlockedCompareExchange8(&state, -1, 0) == -1;
+    return _InterlockedCompareExchange8(&state, -1, 0) == 0;
 };
 
 RED4EXT_INLINE void RED4ext::SharedMutex::lock()
@@ -36,8 +36,7 @@ RED4EXT_INLINE bool RED4ext::SharedMutex::try_lock_shared()
     int32_t currentState = state;
     if (currentState != -1)
     {
-        int32_t expectedNewState = currentState + 1;
-        return _InterlockedCompareExchange8(&state, expectedNewState, currentState) == expectedNewState;
+        return _InterlockedCompareExchange8(&state, currentState + 1, currentState) == currentState;
     }
     return false;
 };

--- a/include/RED4ext/Types/SharedMutex-inl.hpp
+++ b/include/RED4ext/Types/SharedMutex-inl.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/Types/SharedMutex.hpp>
+#endif
+
+RED4EXT_INLINE bool RED4ext::SharedMutex::try_lock()
+{
+    return _InterlockedCompareExchange8(&state, -1, 0) == -1;
+};
+
+RED4EXT_INLINE void RED4ext::SharedMutex::lock()
+{
+    int32_t loopCount = 0;
+    while (true)
+    {
+        if (try_lock())
+            break;
+
+        // The following is not required but prefered
+        ++loopCount;
+        if (loopCount == 0x4000)
+            loopCount = 0;
+        else if (!(loopCount & 511))
+            SwitchToThread();
+    }
+};
+
+RED4EXT_INLINE void RED4ext::SharedMutex::unlock()
+{
+    state = 0;
+};
+
+RED4EXT_INLINE bool RED4ext::SharedMutex::try_lock_shared()
+{
+    int32_t currentState = state;
+    if (currentState != -1)
+    {
+        int32_t expectedNewState = currentState + 1;
+        return _InterlockedCompareExchange8(&state, expectedNewState, currentState) == expectedNewState;
+    }
+    return false;
+};
+
+RED4EXT_INLINE void RED4ext::SharedMutex::lock_shared()
+{
+    int32_t loopCount = 0;
+    while (true)
+    {
+        if (try_lock_shared())
+            break;
+
+        // The following is not required but prefered
+        ++loopCount;
+        if (loopCount == 0x4000)
+            loopCount = 0;
+        else if (!(loopCount & 511))
+            SwitchToThread();
+    }
+};
+
+RED4EXT_INLINE void RED4ext::SharedMutex::unlock_shared()
+{
+    _InterlockedExchangeAdd8(&state, -1);
+};

--- a/include/RED4ext/Types/SharedMutex.hpp
+++ b/include/RED4ext/Types/SharedMutex.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <memory>
+
+#include <Windows.h>
+
+#include <RED4ext/Common.hpp>
+
+namespace RED4ext
+{
+struct SharedMutex
+{
+    // -1 : write
+    // 0 : free
+    // + : read
+    volatile char state;
+
+    bool try_lock();
+    void lock();
+    void unlock();
+
+    bool try_lock_shared();
+    void lock_shared();
+    void unlock_shared();
+};
+}
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/Types/SharedMutex-inl.hpp>
+#endif

--- a/include/RED4ext/Types/SharedMutex.hpp
+++ b/include/RED4ext/Types/SharedMutex.hpp
@@ -14,6 +14,18 @@ struct SharedMutex
     // + : read
     volatile char state;
 
+    bool TryLock();
+    void Lock();
+    void Unlock();
+
+    bool TryLockShared();
+    void LockShared();
+    void UnlockShared();
+
+    // --------------------------------------------
+    // -- support for lock_guard and shared_lock --
+    // --------------------------------------------
+
     bool try_lock();
     void lock();
     void unlock();

--- a/include/RED4ext/Types/SimpleTypes-inl.hpp
+++ b/include/RED4ext/Types/SimpleTypes-inl.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/Types/SimpleTypes.hpp>
+#endif
+
+RED4EXT_INLINE RED4ext::TweakDBID::operator uint64_t() const noexcept
+{
+    return value;
+}
+
+RED4EXT_INLINE bool RED4ext::TweakDBID::operator==(const TweakDBID& aDBID) const noexcept
+{
+    return aDBID.name_hash == name_hash && aDBID.name_length == name_length;
+}
+
+RED4EXT_INLINE bool RED4ext::TweakDBID::IsValid() const noexcept
+{
+    return name_hash != 0 && name_length != 0;
+}
+
+RED4EXT_INLINE uint32_t RED4ext::TweakDBID::ToTDBOffset() const noexcept
+{
+    // swaps 3 bytes
+    // 01 02 03 FF -> 0xFF030201 -> 0x010203
+    return (_byteswap_ulong(*reinterpret_cast<const uint32_t*>(&tdb_offset[0])) >> 8) & 0x00FFFFFF;
+}

--- a/include/RED4ext/Types/SimpleTypes-inl.hpp
+++ b/include/RED4ext/Types/SimpleTypes-inl.hpp
@@ -11,17 +11,17 @@ RED4EXT_INLINE RED4ext::TweakDBID::operator uint64_t() const noexcept
 
 RED4EXT_INLINE bool RED4ext::TweakDBID::operator==(const TweakDBID& aDBID) const noexcept
 {
-    return aDBID.name_hash == name_hash && aDBID.name_length == name_length;
+    return aDBID.nameHash == nameHash && aDBID.nameLength == nameLength;
 }
 
 RED4EXT_INLINE bool RED4ext::TweakDBID::IsValid() const noexcept
 {
-    return name_hash != 0 && name_length != 0;
+    return nameHash != 0 && nameLength != 0;
 }
 
 RED4EXT_INLINE uint32_t RED4ext::TweakDBID::ToTDBOffset() const noexcept
 {
     // swaps 3 bytes
     // 01 02 03 FF -> 0xFF030201 -> 0x010203
-    return (_byteswap_ulong(*reinterpret_cast<const uint32_t*>(&tdb_offset[0])) >> 8) & 0x00FFFFFF;
+    return (_byteswap_ulong(*reinterpret_cast<const uint32_t*>(&tdbOffset[0])) >> 8) & 0x00FFFFFF;
 }

--- a/include/RED4ext/Types/SimpleTypes.hpp
+++ b/include/RED4ext/Types/SimpleTypes.hpp
@@ -40,11 +40,22 @@ RED4EXT_ASSERT_SIZE(CRUIDRef, 0x8);
 struct TweakDBID
 {
 #pragma pack(push, 1)
-    uint32_t name;  // 00 CRC32
-    uint8_t length; // 04
-    uint16_t unk05; // 05
-    uint8_t unk07;  // 07
+    union
+    {
+        uint64_t value = 0;
+        struct
+        {
+            uint32_t name_hash;     // 00 CRC32
+            uint8_t name_length;    // 04
+            uint8_t tdb_offset[3];  // 05
+        };
+    };
 #pragma pack(pop)
+
+    operator uint64_t() const noexcept;
+    bool operator==(const TweakDBID& aDBID) const noexcept;
+    bool IsValid() const noexcept;
+    uint32_t ToTDBOffset() const noexcept;
 };
 RED4EXT_ASSERT_SIZE(TweakDBID, 0x8);
 
@@ -192,4 +203,9 @@ struct ScriptRef
     CName hash;             // 20
 };
 RED4EXT_ASSERT_SIZE(ScriptRef<void>, 0x28);
+
 } // namespace RED4ext
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/Types/SimpleTypes-inl.hpp>
+#endif

--- a/include/RED4ext/Types/SimpleTypes.hpp
+++ b/include/RED4ext/Types/SimpleTypes.hpp
@@ -4,11 +4,14 @@
 #include <cstdint>
 
 #include <RED4ext/CString.hpp>
+#include <RED4ext/CName.hpp>
 #include <RED4ext/Common.hpp>
 #include <RED4ext/Unks.hpp>
 
 namespace RED4ext
 {
+struct IRTTIType;
+
 struct CDateTime
 {
     int64_t unk00; // 00
@@ -180,4 +183,13 @@ struct CurveData
 };
 RED4EXT_ASSERT_SIZE(CurveData<float>, 0x38);
 
+template<typename T>
+struct ScriptRef
+{
+    uint8_t unk00[0x10];    // 00
+    IRTTIType* innerType;   // 10
+    T* ref;                 // 18
+    CName hash;             // 20
+};
+RED4EXT_ASSERT_SIZE(ScriptRef<void>, 0x28);
 } // namespace RED4ext

--- a/include/RED4ext/Types/SimpleTypes.hpp
+++ b/include/RED4ext/Types/SimpleTypes.hpp
@@ -45,9 +45,9 @@ struct TweakDBID
         uint64_t value = 0;
         struct
         {
-            uint32_t name_hash;     // 00 CRC32
-            uint8_t name_length;    // 04
-            uint8_t tdb_offset[3];  // 05
+            uint32_t nameHash;      // 00 CRC32
+            uint8_t nameLength;     // 04
+            uint8_t tdbOffset[3];   // 05
         };
     };
 #pragma pack(pop)

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -41,7 +41,7 @@ RED4EXT_INLINE RED4ext::TweakDB::TweakVal* RED4ext::TweakDB::GetTweakVal(TweakDB
         return nullptr;
 
     // force get offset for now. i don't know if the game sets offset to 0 or leaves it uninitialized..
-    if (true || aDBID.tdb_offset[0] == 0 && aDBID.tdb_offset[1] == 0 && aDBID.tdb_offset[2] == 0)
+    if (true || aDBID.tdbOffset[0] == 0 && aDBID.tdbOffset[1] == 0 && aDBID.tdbOffset[2] == 0)
     {
         const auto it = std::find(values.begin(), values.end(), aDBID);
         return it == values.end() ? nullptr : reinterpret_cast<TweakVal*>(valuesBuffer + it->ToTDBOffset());

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <shared_mutex>
 
 #ifdef RED4EXT_STATIC_LIB
 #include <RED4ext/Types/TweakDB.hpp>
@@ -9,7 +10,10 @@
 
 RED4EXT_INLINE RED4ext::TweakDB::TweakVal* RED4ext::TweakDB::GetTweakVal(TweakDBID aDBID)
 {
-    if (!aDBID.IsValid()) return nullptr;
+    std::shared_lock<SharedMutex> _(mutex00);
+
+    if (!aDBID.IsValid())
+        return nullptr;
 
     // force get offset for now. i don't know if the game sets offset to 0 or leaves it uninitialized..
     if (true || aDBID.tdb_offset[0] == 0 && aDBID.tdb_offset[1] == 0 && aDBID.tdb_offset[2] == 0)

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -31,6 +31,8 @@ RED4EXT_INLINE RED4ext::DynArray<RED4ext::TweakDBID>* RED4ext::TweakDB::GetPacka
         if (packageIDs[i] == aDBID)
             return &packageValues[i];
     }
+
+    return nullptr;
 }
 
 RED4EXT_INLINE RED4ext::TweakDB::TweakVal* RED4ext::TweakDB::GetTweakVal(TweakDBID aDBID)

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/Types/TweakDB.hpp>
+#endif
+
+#include <RED4ext/Addresses.hpp>
+#include <RED4ext/REDptr.hpp>
+
+RED4EXT_INLINE RED4ext::TweakDB::TweakVal* RED4ext::TweakDB::GetTweakVal(TweakDBID aDBID)
+{
+    if (!aDBID.IsValid()) return nullptr;
+
+    // force get offset for now. i don't know if the game sets offset to 0 or leaves it uninitialized..
+    if (true || aDBID.tdb_offset[0] == 0 && aDBID.tdb_offset[1] == 0 && aDBID.tdb_offset[2] == 0)
+    {
+        const auto it = std::find(values.begin(), values.end(), aDBID);
+        return it == values.end() ? nullptr : reinterpret_cast<TweakVal*>(valuesBuffer + it->ToTDBOffset());
+    }
+    return reinterpret_cast<TweakVal*>(valuesBuffer + aDBID.ToTDBOffset());
+}
+
+RED4EXT_INLINE RED4ext::TweakDB* RED4ext::TweakDB::Get()
+{
+    using Get_t = TweakDB* (*)();
+    static REDfunc<Get_t> func(Addresses::TweakDB_Get);
+    return func();
+}
+
+RED4EXT_INLINE bool RED4ext::TweakDB::TweakVal::SetValue(RED4ext::CStackType& aStackType)
+{
+    CStackType stackType;
+    GetValue(&stackType);
+    if (aStackType.type != nullptr)
+    {
+        if (aStackType.type != stackType.type)
+            return false;
+    }
+    // might lead to race conditions.
+    // doing mutex locking here is useless. game accesses "stackType.value" directly by offset into TweakDB::valuesBuffer
+    stackType.type->Assign(stackType.value, aStackType.value);
+    return true;
+}
+
+RED4EXT_INLINE void RED4ext::TweakDB::TweakVal::SetValue(void* apValue)
+{
+    CStackType stackType;
+    stackType.type = nullptr;
+    stackType.value = apValue;
+    SetValue(stackType);
+}

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -8,6 +8,31 @@
 #include <RED4ext/Addresses.hpp>
 #include <RED4ext/REDptr.hpp>
 
+RED4EXT_INLINE RED4ext::Handle<RED4ext::IScriptable>* RED4ext::TweakDB::GetRecord(TweakDBID aDBID)
+{
+    std::shared_lock<SharedMutex> _(mutex01);
+
+    return recordsByID.Get(aDBID);
+}
+
+RED4EXT_INLINE RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>>* RED4ext::TweakDB::GetRecordsByType(IRTTIType* apType)
+{
+    std::shared_lock<SharedMutex> _(mutex01);
+
+    return recordsByType.Get(apType);
+}
+
+RED4EXT_INLINE RED4ext::DynArray<RED4ext::TweakDBID>* RED4ext::TweakDB::GetPackage(TweakDBID aDBID)
+{
+    std::shared_lock<SharedMutex> _(mutex01);
+
+    for (uint32_t i = 0; i != packageIDs.size; ++i)
+    {
+        if (packageIDs[i] == aDBID)
+            return &packageValues[i];
+    }
+}
+
 RED4EXT_INLINE RED4ext::TweakDB::TweakVal* RED4ext::TweakDB::GetTweakVal(TweakDBID aDBID)
 {
     std::shared_lock<SharedMutex> _(mutex00);

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -15,11 +15,11 @@ RED4EXT_INLINE RED4ext::Handle<RED4ext::IScriptable>* RED4ext::TweakDB::GetRecor
     return recordsByID.Get(aDBID);
 }
 
-RED4EXT_INLINE RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>>* RED4ext::TweakDB::GetRecordsByType(IRTTIType* apType)
+RED4EXT_INLINE RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>>* RED4ext::TweakDB::GetRecordsByType(IRTTIType* aType)
 {
     std::shared_lock<SharedMutex> _(mutex01);
 
-    return recordsByType.Get(apType);
+    return recordsByType.Get(aType);
 }
 
 RED4EXT_INLINE RED4ext::DynArray<RED4ext::TweakDBID>* RED4ext::TweakDB::GetPackage(TweakDBID aDBID)
@@ -73,10 +73,10 @@ RED4EXT_INLINE bool RED4ext::TweakDB::TweakVal::SetValue(RED4ext::CStackType& aS
     return true;
 }
 
-RED4EXT_INLINE void RED4ext::TweakDB::TweakVal::SetValue(void* apValue)
+RED4EXT_INLINE void RED4ext::TweakDB::TweakVal::SetValue(void* aValue)
 {
     CStackType stackType;
     stackType.type = nullptr;
-    stackType.value = apValue;
+    stackType.value = aValue;
     SetValue(stackType);
 }

--- a/include/RED4ext/Types/TweakDB.hpp
+++ b/include/RED4ext/Types/TweakDB.hpp
@@ -22,33 +22,33 @@ struct TweakDB
         // those 3 bytes **ARE NOT** TweakDBID::Offset. tweak's offset point to this class and not the value.
 
         virtual ~TweakVal() = 0;
-        virtual bool ToValueOffset_array_TweakDBID(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_TweakDBID(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_Quaternion(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_Quaternion(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_EulerAngles(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_EulerAngles(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_Vector3(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_Vector3(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_Vector2(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_Vector2(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_Color(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_Color(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_gamedataLocKeyWrapper(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_gamedataLocKeyWrapper(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_raRef_CResource(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_raRef_CResource(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_CName(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_CName(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_Bool(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_Bool(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_String(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_String(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_Float(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_Float(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_array_Int32(uint32_t* apValueOffset) = 0;
-        virtual bool ToValueOffset_Int32(uint32_t* apValueOffset) = 0;
-        virtual CStackType* GetValue(CStackType* apStackType) = 0;
+        virtual bool ToValueOffset_array_TweakDBID(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_TweakDBID(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_Quaternion(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_Quaternion(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_EulerAngles(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_EulerAngles(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_Vector3(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_Vector3(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_Vector2(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_Vector2(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_Color(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_Color(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_gamedataLocKeyWrapper(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_gamedataLocKeyWrapper(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_raRef_CResource(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_raRef_CResource(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_CName(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_CName(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_Bool(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_Bool(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_String(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_String(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_Float(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_Float(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_array_Int32(uint32_t* aValueOffset) = 0;
+        virtual bool ToValueOffset_Int32(uint32_t* aValueOffset) = 0;
+        virtual CStackType* GetValue(CStackType* aStackType) = 0;
 
         template<typename T>
         T* GetValue()
@@ -59,7 +59,7 @@ struct TweakDB
         }
 
         bool SetValue(CStackType& aStackType);
-        void SetValue(void* apValue);
+        void SetValue(void* aValue);
 
         // value here
     };
@@ -106,7 +106,7 @@ struct TweakDB
     }
 
     Handle<IScriptable>* GetRecord(TweakDBID aDBID);
-    DynArray<Handle<IScriptable>>* GetRecordsByType(IRTTIType* apType);
+    DynArray<Handle<IScriptable>>* GetRecordsByType(IRTTIType* aType);
     DynArray<TweakDBID>* GetPackage(TweakDBID aDBID);
     TweakVal* GetTweakVal(TweakDBID aDBID);
     static TweakDB* Get();

--- a/include/RED4ext/Types/TweakDB.hpp
+++ b/include/RED4ext/Types/TweakDB.hpp
@@ -1,0 +1,113 @@
+#pragma once
+#include <cstdint>
+
+#include <RED4ext/Common.hpp>
+#include <RED4ext/DynArray.hpp>
+#include <RED4ext/HashMap.hpp>
+#include <RED4ext/Handle.hpp>
+#include <RED4ext/Types/SharedMutex.hpp>
+#include <RED4ext/Types/SimpleTypes.hpp>
+#include <RED4ext/RTTITypes.hpp>
+#include <RED4ext/Scripting/Stack.hpp> // Might need an alternative to CStackType
+
+namespace RED4ext
+{
+struct IScriptable;
+
+struct TweakDB
+{
+    struct TweakVal
+    {
+        // ToValueOffset here is the 3bytes stored in records.
+        // those 3 bytes **ARE NOT** TweakDBID::Offset. tweak's offset point to this class and not the value.
+
+        virtual ~TweakVal() = 0;
+        virtual bool ToValueOffset_array_TweakDBID(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_TweakDBID(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_Quaternion(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_Quaternion(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_EulerAngles(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_EulerAngles(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_Vector3(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_Vector3(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_Vector2(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_Vector2(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_Color(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_Color(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_gamedataLocKeyWrapper(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_gamedataLocKeyWrapper(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_raRef_CResource(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_raRef_CResource(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_CName(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_CName(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_Bool(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_Bool(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_String(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_String(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_Float(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_Float(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_array_Int32(uint32_t* apValueOffset) = 0;
+        virtual bool ToValueOffset_Int32(uint32_t* apValueOffset) = 0;
+        virtual CStackType* GetValue(CStackType* apStackType) = 0;
+
+        bool SetValue(CStackType& aStackType);
+        void SetValue(void* apValue);
+
+        // value here
+    };
+
+    enum class TweakGroupFlag : int8_t
+    {
+        None            = 0,
+        Abstract        = 1 << 0,
+        NotQueryable    = 1 << 1,
+        CPO             = 1 << 2,
+        Debug           = 1 << 3
+    };
+
+    SharedMutex mutex00;                                                    // 00 - used with values, valuesBuffer*, 
+    SharedMutex mutex01;                                                    // 01 - used with recordsByID, recordsByType, packageIDs, packageValues, groups and groupFlags
+    void* unk08;                                                            // 08 - class - 264 bytes - has DynArray<GroupFlagCName> and DynArray<FlagVal-1byte>
+    void* unk10;                                                            // 10 - class - 208 bytes
+    bool unk18;                                                             // 18
+    DynArray<TweakDBID> values;                                             // 20
+    uint64_t unk30;                                                         // 30
+    HashMap<TweakDBID, Handle<IScriptable>> recordsByID;                    // 38
+    HashMap<IRTTIType*, DynArray<Handle<IScriptable>>> recordsByType;       // 68
+    DynArray<TweakDBID> packageIDs;                                         // 98
+    DynArray<DynArray<TweakDBID>> packageValues;                            // A8
+    uint32_t unkB8;                                                         // B8
+    uint32_t unkBC;                                                         // BC
+    DynArray<TweakDBID> groups;                                             // C0
+    DynArray<TweakGroupFlag> groupFlags;                                    // D0
+    uint64_t unkE0;                                                         // E0
+    HashMap<CName, TweakVal*> defaultValueByType;                           // E8
+    DynArray<CString> unk118;                                               // 118 - empty - maybe not CString
+    uintptr_t valuesBuffer;                                                 // 128
+    uint32_t valuesBufferSize;                                              // 130
+    uintptr_t valuesBufferEnd;                                              // 138
+
+    template<typename T>
+    RED4EXT_INLINE T* GetVal(TweakDBID aDBID)
+    {
+        auto* tweakVal = GetTweakVal(aDBID);
+        if (tweakVal == nullptr)
+            return nullptr;
+
+        CStackType stackType;
+        tweakVal->GetValue(&stackType);
+        return reinterpret_cast<T*>(stackType.value);
+    }
+
+    TweakVal* GetTweakVal(TweakDBID aDBID);
+    static TweakDB* Get();
+};
+RED4EXT_ASSERT_OFFSET(TweakDB, unk08, 0x08);
+RED4EXT_ASSERT_OFFSET(TweakDB, values, 0x20);
+RED4EXT_ASSERT_OFFSET(TweakDB, valuesBufferEnd, 0x138);
+RED4EXT_ASSERT_SIZE(TweakDB, 0x140);
+}
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/Types/TweakDB-inl.hpp>
+#endif

--- a/include/RED4ext/Types/TweakDB.hpp
+++ b/include/RED4ext/Types/TweakDB.hpp
@@ -99,6 +99,9 @@ struct TweakDB
         return reinterpret_cast<T*>(stackType.value);
     }
 
+    Handle<IScriptable>* GetRecord(TweakDBID aDBID);
+    DynArray<Handle<IScriptable>>* GetRecordsByType(IRTTIType* apType);
+    DynArray<TweakDBID>* GetPackage(TweakDBID aDBID);
     TweakVal* GetTweakVal(TweakDBID aDBID);
     static TweakDB* Get();
 };

--- a/include/RED4ext/Types/TweakDB.hpp
+++ b/include/RED4ext/Types/TweakDB.hpp
@@ -65,7 +65,7 @@ struct TweakDB
         Debug           = 1 << 3
     };
 
-    SharedMutex mutex00;                                                    // 00 - used with values, valuesBuffer*, 
+    SharedMutex mutex00;                                                    // 00 - used with values and valuesBuffer*
     SharedMutex mutex01;                                                    // 01 - used with recordsByID, recordsByType, packageIDs, packageValues, groups and groupFlags
     void* unk08;                                                            // 08 - class - 264 bytes - has DynArray<GroupFlagCName> and DynArray<FlagVal-1byte>
     void* unk10;                                                            // 10 - class - 208 bytes

--- a/include/RED4ext/Types/TweakDB.hpp
+++ b/include/RED4ext/Types/TweakDB.hpp
@@ -50,6 +50,14 @@ struct TweakDB
         virtual bool ToValueOffset_Int32(uint32_t* apValueOffset) = 0;
         virtual CStackType* GetValue(CStackType* apStackType) = 0;
 
+        template<typename T>
+        T* GetValue()
+        {
+            CStackType stackType;
+            GetValue(&stackType);
+            return reinterpret_cast<T*>(stackType.value);
+        }
+
         bool SetValue(CStackType& aStackType);
         void SetValue(void* apValue);
 
@@ -88,15 +96,13 @@ struct TweakDB
     uintptr_t valuesBufferEnd;                                              // 138
 
     template<typename T>
-    RED4EXT_INLINE T* GetVal(TweakDBID aDBID)
+    T* GetValue(TweakDBID aDBID)
     {
         auto* tweakVal = GetTweakVal(aDBID);
         if (tweakVal == nullptr)
             return nullptr;
-
-        CStackType stackType;
-        tweakVal->GetValue(&stackType);
-        return reinterpret_cast<T*>(stackType.value);
+        
+        return tweakVal->GetValue<T>();
     }
 
     Handle<IScriptable>* GetRecord(TweakDBID aDBID);

--- a/scripts/patterns.py
+++ b/scripts/patterns.py
@@ -66,5 +66,9 @@ def get_groups() -> List[Group]:
         Group(name='Handle', functions=[
             Item(name='ctor', pattern='48 89 5C 24 18 48 89 6C 24 20 57 48 83 EC 60 33 ED', expected=1, index=0),
             Item(name='DecWeakRef', pattern='40 53 48 83 EC 30 48 8B D9 48 8B 49 08 48 85 C9 74 43 B8 FF FF FF FF', expected=1, index=0)
+        ]),
+
+        Group(name='TweakDB', functions=[
+            Item(name='Get', pattern='48 83 EC 48 48 8B 05 ? ? ? ? 48 85 C0 0F 85 8A 00 00 00', expected=1, index=0)
         ])
     ]

--- a/src/Types/SharedMutex.cpp
+++ b/src/Types/SharedMutex.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/Types/SharedMutex-inl.hpp>

--- a/src/Types/SimpleTypes.cpp
+++ b/src/Types/SimpleTypes.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/Types/SimpleTypes-inl.hpp>

--- a/src/Types/TweakDB.cpp
+++ b/src/Types/TweakDB.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/Types/TweakDB-inl.hpp>


### PR DESCRIPTION
### • Fixed Hashmap
1. [Removed] HashMapBase was missing a u64 allocator at the end
2. [Fixed] HashMap had an extra u64 at the beginning which should have been at the end
3. Adjusted offsets in classes/structs that used HashMap and HashMapBase
4. Added HashMap::GetAllocator() 
5. Added custom hasher to HashMap<Key, Value, Hasher>. defaults to casting to u32 if possible
### • TweakDB
Currently missing 2 classes for unk08 and unk10, will do them eventually if they're useful
Experimental design, any changes are welcome :)
```cpp
auto* tdb = TweakDB::Get();

// Read
{
  TweakDBID dbid;
  dbid.name_hash = 0x68D39470;
  dbid.name_length = 52;
  auto* unitCount = tdb->GetVal<int32_t>(dbid);
  printf("unitsCount: %d\n", *unitCount);
}

// Read - 2
{
  TweakDBID dbid;
  dbid.name_hash = 0x68D39470;
  dbid.name_length = 52;
  auto* tweakVal = tdb->GetTweakVal(dbid);
  IRTTIType* rttiType = tweakVal->type;
  auto* unitCount = (int32_t*)tweakVal->value;
  printf("unitsCount: %d\n", *unitCount);
}

// Write
{
  TweakDBID dbid;
  dbid.name_hash = 0x68D39470;
  dbid.name_length = 52;
  auto* tweakVal = tdb->GetTweakVal(dbid);
  if (tweakVal == nullptr)
  {
    puts("tweakVal was null");
    return;
  }
  int newUnitCount = 10;
  tweakVal->SetValue(&newUnitCount); // Or you can pass CStackType which will do "IsExact" type checking
}

// tdb->GetRecord(...)
// tdb->GetRecordsByType(...)
// tdb->GetPackage(...)
```
### • Other
1. Added begin/end to DynArray as a QoL to allow range based iteration
2. Renamed some fields in TweakDBID, added a union and some operators
3. Added script_ref type for scripting