### PR TITLE
Fixed IMemoryAllocator::Free

### DIFF
--- a/include/RED4ext/MemoryAllocators.hpp
+++ b/include/RED4ext/MemoryAllocators.hpp
@@ -19,7 +19,7 @@ struct IMemoryAllocator
     virtual Result AllocAligned(uint32_t aSize, uint32_t aAlignment) = 0;
     virtual void sub_10() = 0;
     virtual void sub_18() = 0;
-    virtual void Free(void* aMemory) = 0;
+    virtual void Free(Result* aAllocResult) = 0;
     virtual void sub_28(void* aMemory) = 0;
     virtual uint32_t GetId() = 0;
 
@@ -28,6 +28,14 @@ struct IMemoryAllocator
     {
         auto result = Alloc(sizeof(T));
         return static_cast<T*>(result.memory);
+    }
+
+    void Free(void* aMemory)
+    {
+        Result allocResult;
+        allocResult.memory = aMemory;
+        allocResult.size = 0;
+        Free(&allocResult);
     }
 };
 RED4EXT_ASSERT_SIZE(IMemoryAllocator, 0x8);

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -119,9 +119,9 @@ RED4EXT_INLINE bool RED4ext::TweakDB::UpdateRecord(gamedataTweakDBRecord* aRecor
             { }
             virtual void sub_18()
             { }
-            virtual void Free(void* aMemory)
+            virtual void Free(Result* aMemory)
             {
-                _aligned_free(aMemory);
+                _aligned_free(aMemory->memory);
             }
             virtual void sub_28(void* aMemory)
             { };
@@ -164,8 +164,8 @@ RED4EXT_INLINE bool RED4ext::TweakDB::UpdateRecord(gamedataTweakDBRecord* aRecor
             {
                 aRecord->GetNativeType()->Assign(aRecord, handle.instance);
                 DeleteHandle(handle);
-                updated = true;
             });
+        updated = true;
     }
 
     // free the hashmaps in our fakeTweakDB


### PR DESCRIPTION
The game passes a structure containing the pointer, as seen here:
![allocatorfix](https://user-images.githubusercontent.com/26506177/108281889-51194180-7189-11eb-90fa-b4a13e657f0f.PNG)
The game eventually crashes without this fix