### PR TITLE
TweakDB, DynArray and HashMap

### DIFF
--- a/include/RED4ext/DynArray.hpp
+++ b/include/RED4ext/DynArray.hpp
@@ -68,8 +68,10 @@ struct DynArray
         entries[aIndex].~T();
         if ((aIndex + 1) < size)
         {
+            // This should use std::move assignments if possible, but this is easier
+
             size_t entriesCount = size - (aIndex + 1);
-            std::memcpy(&entries[aIndex], &entries[aIndex + 1], entriesCount * sizeof(T));
+            std::memmove(&entries[aIndex], &entries[aIndex + 1], entriesCount * sizeof(T));
         }
         --size;
         return true;

--- a/include/RED4ext/HashMap.hpp
+++ b/include/RED4ext/HashMap.hpp
@@ -4,121 +4,326 @@
 #include <functional>
 
 #include <RED4ext/Common.hpp>
+#include <RED4ext/MemoryAllocators.hpp>
 #include <RED4ext/REDhash.hpp>
 
 namespace RED4ext
 {
-struct IMemoryAllocator;
-
 #pragma region HashMapHash
-    template<typename T, typename enable = void /* for enable_if specialization */>
-    struct HashMapHash
+template<typename T, typename enable = void /* for enable_if specialization */>
+struct HashMapHash
+{
+    uint32_t operator()(const T& aKey) const noexcept
     {
-        uint32_t operator()(const T& aKey) const noexcept
-        {
-            // You can pass your own hasher as the 3rd template argument to the HashMap
-            // Or you can make a specialized version of this class
+        // You can pass your own hasher as the 3rd template argument to the HashMap
+        // Or you can make a specialized version of this class
 
-            static_assert(false, "Please define a HashMapHash<T> specialization for your key type.");
-        }
-    };
+        static_assert(false, "Please define a HashMapHash<T> specialization for your key type.");
+    }
+};
 
-    template<typename T>
-    struct HashMapHash<T, std::enable_if_t<std::is_convertible_v<T, uint32_t>>>
+template<typename T>
+struct HashMapHash<T, std::enable_if_t<std::is_convertible_v<T, uint32_t>>>
+{
+    // Let's give this a try :)
+
+    uint32_t operator()(const T& aKey) const noexcept
     {
-        // Let's give this a try :)
+        return static_cast<uint32_t>(aKey);
+    }
+};
 
-        uint32_t operator()(const T& aKey) const noexcept
-        {
-            return static_cast<uint32_t>(aKey);
-        }
-    };
+template<typename T>
+struct HashMapHash<T, std::enable_if_t<std::is_pointer_v<T>>>
+{
+    // Used in TweakDB, probably the same for all pointer keys
 
-    template<typename T>
-    struct HashMapHash<T, std::enable_if_t<std::is_pointer_v<T>>>
+    uint32_t operator()(const T& aKey) const noexcept
     {
-        // Used in TweakDB, probably the same for all pointer keys
-
-        uint32_t operator()(const T& aKey) const noexcept
-        {
-            return FNV1a32(reinterpret_cast<const uint8_t*>(&aKey), sizeof(void*));
-        }
-    };
+        return FNV1a32(reinterpret_cast<const uint8_t*>(&aKey), sizeof(void*));
+    }
+};
 #pragma endregion
 
-    template<typename K, typename T, typename Hasher = HashMapHash<K>>
-    struct HashMap
+template<typename K, typename T, typename Hasher = HashMapHash<K>>
+struct HashMap
+{
+    static const uint32_t INVALID_INDEX = -1;
+
+    struct Node
     {
-        static const uint32_t INVALID_INDEX = -1;
+        uint32_t next;      // 00
+        uint32_t hashedKey; // 04
+        K key;              // 08
+        T value;            // 10
+    };
 
-        struct Node
+    struct NodeList
+    {
+        Node* nodes;        // 00
+        uint32_t capacity;  // 08
+        uint32_t stride;    // 0C - sizeof(Node)
+        uint32_t nextIdx;   // 10 - next available node index to write to
+        uint32_t size;      // 14
+
+        NodeList(Node* aNodes = nullptr, uint32_t aCapacity = 0)
         {
-            uint32_t next;  // 00
-            uint32_t index; // 04
-            K key;          // 08
-            T value;        // 10
-        };
-
-        void for_each(std::function<void(const K&, T&)> aFunctor) const
-        {
-            for (uint32_t index = 0; index != capacity; ++index)
-            {
-                uint32_t idx = indexTable[index];
-
-                while (idx != INVALID_INDEX)
-                {
-                    Node* node = reinterpret_cast<Node*>(nodes + idx * stride);
-                    if (!node)
-                    {
-                        break;
-                    }
-
-                    aFunctor(node->key, node->value);
-
-                    idx = node->next;
-                }
-            }
+            nodes = aNodes;
+            capacity = aCapacity;
+            stride = sizeof(Node);
+            nextIdx = aNodes ? 0 : -1;
+            size = 0;
         }
 
-        T* Get(const K& aKey) const
+        Node* GetNextAvailNode()
         {
-            Node* found = nullptr;
-            uint32_t hashedKey = Hasher{}(aKey);
+            if (nextIdx == -1)
+                return nullptr;
+
+            if (size == nextIdx)
+            {
+                if (size + 1 < capacity)
+                {
+                    ++size;
+                    return &nodes[nextIdx++];
+                }
+                else
+                {
+                    Node* node = &nodes[nextIdx];
+                    nextIdx = -1;
+                    return node;
+                }
+            }
+            else
+            {
+                Node* node = &nodes[nextIdx];
+                nextIdx = node->next;
+                return node;
+            }
+        }
+    };
+
+    void for_each(std::function<void(const K&, T&)> aFunctor) const
+    {
+        if (size == 0)
+            return;
+
+        for (uint32_t index = 0; index != capacity; ++index)
+        {
+            uint32_t idx = indexTable[index];
+            while (idx != INVALID_INDEX)
+            {
+                Node* node = &nodeList.nodes[idx];
+                aFunctor(node->key, node->value);
+                idx = node->next;
+            }
+        }
+    }
+
+    T* Get(const K& aKey) const
+    {
+        if (size == 0)
+            return nullptr;
+
+        uint32_t hashedKey = Hasher{}(aKey);
+        uint32_t idx = indexTable[hashedKey % capacity];
+        while (idx != INVALID_INDEX)
+        {
+            Node* node = &nodeList.nodes[idx];
+            if (node->hashedKey == hashedKey && node->key == aKey)
+            {
+                return &node->value;
+            }
+
+            idx = node->next;
+        }
+
+        return nullptr;
+    }
+
+    bool Remove(const K& aKey)
+    {
+        // This function is guessed based on how the other functions are implemented
+        // Couldn't easily find it in the game -Sombra
+
+        if (size == 0)
+            return false;
+
+        uint32_t hashedKey = Hasher{}(aKey);
+        uint32_t idx = indexTable[hashedKey % capacity];
+        while (idx != INVALID_INDEX)
+        {
+            Node* prevNode = nullptr;
+            Node* node = &nodeList.nodes[idx];
+            if (node->hashedKey == hashedKey && node->key == aKey)
+            {
+                if (prevNode == nullptr)
+                    indexTable[hashedKey % capacity] = node->next;
+                else
+                    prevNode->next = node->next;
+
+                node->next = nodeList.nextIdx;
+                nodeList.nextIdx = static_cast<uint32_t>(node - nodeList.nodes);
+                //--nodeList.size;
+                --size;
+                return true;
+            }
+            prevNode = node;
+            idx = node->next;
+        }
+
+        return false;
+    }
+
+    std::pair<Node*, bool> Insert(const K& aKey, const T& aValue)
+    {
+        return Emplace(aKey, std::forward<const T&>(aValue));
+    }
+
+    std::pair<Node*, bool> Insert(const K& aKey, T&& aValue)
+    {
+        return Emplace(aKey, std::forward<T&&>(aValue));
+    }
+
+    std::pair<Node*, bool> InsertOrAssign(const K& aKey, const T& aValue)
+    {
+        std::pair<Node*, bool> pair = Emplace(aKey, aValue);
+        if (!pair.second)
+        {
+            pair.first->value = aValue;
+        }
+        return pair;
+    }
+
+    std::pair<Node*, bool> InsertOrAssign(const K& aKey, T&& aValue)
+    {
+        std::pair<Node*, bool> pair = Emplace(aKey, std::forward<T&&>(aValue));
+        if (!pair.second)
+        {
+            pair.first->value = std::move(aValue);
+        }
+        return pair;
+    }
+
+    template<class... TArgs>
+    std::pair<Node*, bool> Emplace(const K& aKey, TArgs&&... aArgs)
+    {
+        uint32_t hashedKey = Hasher{}(aKey);
+
+        if (size != 0 && indexTable[hashedKey % capacity] != -1)
+        {
             uint32_t idx = indexTable[hashedKey % capacity];
             while (idx != INVALID_INDEX)
             {
-                Node* node = reinterpret_cast<Node*>(nodes + idx * stride);
-                if (node->index == hashedKey && node->key == aKey)
+                Node* node = &nodeList.nodes[idx];
+                if (node->hashedKey == hashedKey && node->key == aKey)
                 {
-                    found = node;
-                    break;
+                    return { node, false };
                 }
 
                 idx = node->next;
             }
+        }
 
-            if (found)
+        if (size + 1 > capacity)
+        {
+            uint32_t newCapacity = size + (size / 2);
+            if (newCapacity < 4)
+                newCapacity = 4;
+            Reserve(newCapacity);
+        }
+
+        // shouldn't be null. The game doesn't even check
+        Node* node = nodeList.GetNextAvailNode();
+        node->hashedKey = hashedKey;
+        new (&node->key) K(aKey);
+        new (&node->value) T(std::forward<TArgs>(aArgs)...);
+        node->next = indexTable[hashedKey % capacity];
+        indexTable[hashedKey % capacity] = static_cast<uint32_t>(node - nodeList.nodes);
+        ++size;
+        return { node, true };
+    }
+
+    void Clear()
+    {
+        for (uint32_t i = 0; i != capacity; ++i)
+        {
+            uint32_t idx = indexTable[i];
+            while (idx != INVALID_INDEX)
             {
-                return &found->value;
+                Node* node = &nodeList.nodes[idx];
+                idx = node->next;
+                node->~Node();
             }
 
-            return nullptr;
+            indexTable[i] = -1;
         }
+        size = 0;
+        nodeList.nextIdx = 0;
+        nodeList.size = 0;
+    }
 
-        IMemoryAllocator* GetAllocator()
+    void Reserve(uint32_t aSize)
+    {
+        if (aSize <= capacity)
+            return;
+
+        size_t requiredBytes = aSize * (sizeof(Node) + 4 /* *indexTable */);
+        auto allocResult = GetAllocator()->AllocAligned(requiredBytes, 8);
+        memset(allocResult.memory, 0, allocResult.size);
+        NodeList newNodeList(reinterpret_cast<Node*>(allocResult.memory), aSize);
+        uint32_t* newIndexTable = reinterpret_cast<uint32_t*>((uintptr_t)allocResult.memory + (aSize * sizeof(Node)));
+
+        for (uint32_t i = 0; i != aSize; ++i)
         {
-            return reinterpret_cast<IMemoryAllocator*>(&allocator);
+            newIndexTable[i] = -1;
         }
 
-        uint32_t* indexTable;   // 00
-        uint32_t size;          // 08
-        uint32_t capacity;      // 0C
-        uintptr_t nodes;        // 10
-        uint32_t unk18;         // 18
-        uint32_t stride;        // 1C - sizeof(Node)
-        uint32_t unk20;         // 20
-        uint32_t unk24;         // 24
-        uintptr_t allocator;    // 28
-    };
-    RED4EXT_ASSERT_SIZE(RED4EXT_ASSERT_ESCAPE(HashMap<uint64_t, void*>), 0x30);    
+        if (capacity != 0)
+        {
+            if (size != 0)
+            {
+                for (uint32_t i = 0; i != capacity; ++i)
+                {
+                    uint32_t idx = indexTable[i];
+                    while (idx != INVALID_INDEX)
+                    {
+                        Node* oldNode = &nodeList.nodes[idx];
+                        uint32_t hashedKey = oldNode->hashedKey;
+
+                        Node* node = newNodeList.GetNextAvailNode();
+                        node->hashedKey = hashedKey;
+                        new(&node->key) K(std::move(oldNode->key));
+                        new (&node->value) T(std::move(oldNode->value));
+                        node->next = newIndexTable[hashedKey % aSize];
+                        newIndexTable[hashedKey % aSize] = static_cast<uint32_t>(node - newNodeList.nodes);
+
+                        idx = oldNode->next;
+                        oldNode->~Node();
+                    }
+
+                    indexTable[i] = -1;
+                }
+            }
+
+            GetAllocator()->Free(nodeList.nodes);
+        }
+
+        capacity = aSize;
+        indexTable = newIndexTable;
+        nodeList = newNodeList;
+    }
+
+    IMemoryAllocator* GetAllocator()
+    {
+        return reinterpret_cast<IMemoryAllocator*>(&allocator);
+    }
+
+    uint32_t* indexTable;   // 00
+    uint32_t size;          // 08
+    uint32_t capacity;      // 0C
+    NodeList nodeList;      // 10
+    uintptr_t allocator;    // 28
+};
+RED4EXT_ASSERT_SIZE(RED4EXT_ASSERT_ESCAPE(HashMap<uint64_t, void*>), 0x30);
 } // namespace RED4ext

--- a/include/RED4ext/RTTITypes.hpp
+++ b/include/RED4ext/RTTITypes.hpp
@@ -38,29 +38,29 @@ struct IRTTIType
 {
     virtual ~IRTTIType() = 0; // 00
 
-    virtual void GetName(CName& aOut) const = 0;                                    // 08
-    virtual uint32_t GetSize() const = 0;                                           // 10
-    virtual uint32_t GetAlignment() const = 0;                                      // 18
-    virtual ERTTIType GetType() const = 0;                                          // 20
-    virtual void GetTypeName(CString& aOut) const = 0;                              // 28
-    virtual void GetName2(CName& aOut) const = 0;                                   // 30
-    virtual void Init(void* aMemory) const = 0;                                     // 38
-    virtual void Destroy(void* aMemory) const = 0;                                  // 40
-    virtual bool IsEqual(const ScriptInstance aLhs, const ScriptInstance aRhs) = 0; // 48
-    virtual void Assign(ScriptInstance aLhs, const ScriptInstance aRhs) = 0;        // 50
-    virtual void sub_58(ScriptInstance aLhs, const ScriptInstance aRhs) = 0;        // 58 This usually call "Assign".
-    virtual void sub_60() = 0;                                                      // 60
-    virtual bool GetDebugString(ScriptInstance aInstance, CString& aOut) const = 0; // 68
-    virtual void sub_70() = 0;                                                      // 70
-    virtual void sub_78() = 0;                                                      // 78
-    virtual void sub_80() = 0;                                                      // 80
-    virtual void sub_88() = 0;                                                      // 88
-    virtual bool Unk_90(uintptr_t unk1, uintptr_t unk2, CString& unk3, uintptr_t& unk4) = 0;               // 90
-    virtual bool Unk_98(uintptr_t unk1, uintptr_t unk2, CString& unk3, uintptr_t& unk4, uint8_t unk5) = 0; // 98
-    virtual void sub_A0() = 0;                                                                             // A0
-    virtual bool sub_A8() = 0;                                                                             // A8
-    virtual void sub_B0() = 0;                                                                             // B0
-    virtual IMemoryAllocator* GetAllocator() const = 0;                                                    // B8
+    virtual void GetName(CName& aOut) const = 0;                                                            // 08
+    virtual uint32_t GetSize() const = 0;                                                                   // 10
+    virtual uint32_t GetAlignment() const = 0;                                                              // 18
+    virtual ERTTIType GetType() const = 0;                                                                  // 20
+    virtual void GetTypeName(CString& aOut) const = 0;                                                      // 28
+    virtual void GetName2(CName& aOut) const = 0;                                                           // 30
+    virtual void Init(void* aMemory) const = 0;                                                             // 38
+    virtual void Destroy(void* aMemory) const = 0;                                                          // 40
+    virtual bool IsEqual(const ScriptInstance aLhs, const ScriptInstance aRhs) = 0;                         // 48
+    virtual void Assign(ScriptInstance aLhs, const ScriptInstance aRhs) = 0;                                // 50
+    virtual void Move(ScriptInstance aLhs, const ScriptInstance aRhs) = 0;                                  // 58
+    virtual void sub_60() = 0;                                                                              // 60
+    virtual bool GetDebugString(ScriptInstance aInstance, CString& aOut) const = 0;                         // 68
+    virtual bool sub_70() = 0;                                                                              // 70
+    virtual bool sub_78() = 0;                                                                              // 78
+    virtual void sub_80() = 0;                                                                              // 80
+    virtual void sub_88() = 0;                                                                              // 88
+    virtual bool Unk_90(uintptr_t unk1, uintptr_t unk2, CString& unk3, uintptr_t& unk4) = 0;                // 90
+    virtual bool Unk_98(uintptr_t unk1, uintptr_t unk2, CString& unk3, uintptr_t& unk4, uint8_t unk5) = 0;  // 98
+    virtual void sub_A0() = 0;                                                                              // A0
+    virtual bool sub_A8() = 0;                                                                              // A8
+    virtual void sub_B0() = 0;                                                                              // B0
+    virtual IMemoryAllocator* GetAllocator() const = 0;                                                     // B8
 };
 RED4EXT_ASSERT_SIZE(IRTTIType, 0x8);
 
@@ -72,17 +72,22 @@ RED4EXT_ASSERT_SIZE(CRTTIType, 0x10);
 
 struct CArrayBase : CRTTIType
 {
-    virtual CRTTIType* GetInnerType() const = 0;                                            // C0
-    virtual bool sub_C8() = 0;                                                              // C8 ret 1
-    virtual uint32_t GetLength(ScriptInstance aInstance) const = 0;                         // D0
-    virtual int32_t GetMaxLength() const = 0;                                               // D8 ret -1
-    virtual ScriptInstance GetElement(ScriptInstance aInstance, uint32_t aIndex) const = 0; // E0
+    virtual CRTTIType* GetInnerType() const = 0;                                                    // C0
+    virtual bool sub_C8() = 0;                                                                      // C8 ret 1
+    virtual uint32_t GetLength(ScriptInstance aInstance) const = 0;                                 // D0
+    virtual int32_t GetMaxLength() const = 0;                                                       // D8 ret -1
+    virtual ScriptInstance GetElement(ScriptInstance aInstance, uint32_t aIndex) const = 0;         // E0
     virtual ScriptInstance GetValuePointer(ScriptInstance aInstance,
-                                           uint32_t aIndex) const = 0; // E8 Same func at 0xE0 ?
-    virtual int32_t sub_F0(ScriptInstance aInstance, int32_t aIndex, ScriptInstance aElement) = 0; // F0
-    virtual bool sub_F8(ScriptInstance aInstance, int32_t aIndex) = 0;                             // F8
-    virtual bool sub_100(ScriptInstance aInstance, int32_t aIndex) = 0;                            // 100
-    virtual bool Resize(ScriptInstance aInstance, uint32_t aSize) = 0;                             // 108
+                                           uint32_t aIndex) const = 0;                              // E8 Same func at 0xE0 ?
+    virtual int32_t sub_F0(ScriptInstance aInstance, int32_t aIndex, ScriptInstance aElement) = 0;  // F0
+    virtual bool RemoveAt(ScriptInstance aInstance, int32_t aIndex) = 0;                            // F8
+    // [1, 2, 3]
+    // RTTI->InsertAt(aIndex: 1);
+    // [1, 2 (freed/destroyed), 2, 3]
+    // InnerRTTI->Assign(RTTI->GetElement(aIndex: 1), newValue)
+    // [1, newValue, 2, 3]
+    virtual bool InsertAt(ScriptInstance aInstance, int32_t aIndex) = 0;                            // 100
+    virtual bool Resize(ScriptInstance aInstance, uint32_t aSize) = 0;                              // 108
 };
 
 struct CArray : CArrayBase

--- a/include/RED4ext/Types/SimpleTypes-inl.hpp
+++ b/include/RED4ext/Types/SimpleTypes-inl.hpp
@@ -69,3 +69,8 @@ RED4EXT_INLINE bool RED4ext::TweakDBID::operator==(const TweakDBID& aDBID) const
 {
     return aDBID.nameHash == nameHash && aDBID.nameLength == nameLength;
 }
+
+RED4EXT_INLINE bool RED4ext::TweakDBID::operator!=(const TweakDBID& aDBID) const noexcept
+{
+    return !(aDBID == *this);
+}

--- a/include/RED4ext/Types/SimpleTypes.hpp
+++ b/include/RED4ext/Types/SimpleTypes.hpp
@@ -66,6 +66,7 @@ struct TweakDBID
     TweakDBID& operator=(const std::string_view aName) noexcept;
     TweakDBID operator+(const std::string_view aName) const noexcept;
     bool operator==(const TweakDBID& aDBID) const noexcept;
+    bool operator!=(const TweakDBID& aDBID) const noexcept;
 };
 RED4EXT_ASSERT_SIZE(TweakDBID, 0x8);
 

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -295,8 +295,7 @@ RED4EXT_INLINE RED4ext::TweakDB* RED4ext::TweakDB::Get()
 
 RED4EXT_INLINE bool RED4ext::TweakDB::FlatValue::SetValue(const RED4ext::CStackType& aStackType)
 {
-    CStackType stackType;
-    GetValue(&stackType);
+    CStackType stackType = GetValue();
     if (aStackType.type != nullptr)
     {
         if (aStackType.type != stackType.type)

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -138,18 +138,13 @@ RED4EXT_INLINE bool RED4ext::TweakDB::UpdateRecord(gamedataTweakDBRecord* aRecor
             pHashMap->indexTable = nullptr;
             pHashMap->size = 0;
             pHashMap->capacity = 0;
-            pHashMap->nodes = 0;
-            pHashMap->unk18 = 0;
-            pHashMap->stride = static_cast<int32_t>(aStride);
-            pHashMap->unk20 = -1;
-            pHashMap->unk24 = 0;
             pHashMap->allocator = *reinterpret_cast<uintptr_t*>(&fakeAllocator); // vftable
         };
 
         fakeTweakDB.mutex00.state = 0;
         fakeTweakDB.mutex01.state = 0;
-        initializeHashMap(&fakeTweakDB.recordsByID, sizeof(HashMap<TweakDBID, Handle<gamedataTweakDBRecord>>::Node));
-        initializeHashMap(&fakeTweakDB.recordsByType, sizeof(HashMap<IRTTIType*, DynArray<Handle<gamedataTweakDBRecord>>>::Node));
+        initializeHashMap(&fakeTweakDB.recordsByID, sizeof(decltype(fakeTweakDB.recordsByID)::Node));
+        initializeHashMap(&fakeTweakDB.recordsByType, sizeof(decltype(fakeTweakDB.recordsByType)::Node));
 
         fakeTweakDBInitialized = true;
     }
@@ -168,28 +163,15 @@ RED4EXT_INLINE bool RED4ext::TweakDB::UpdateRecord(gamedataTweakDBRecord* aRecor
         updated = true;
     }
 
-    // free the hashmaps in our fakeTweakDB
+    // clear the hashmaps in our fakeTweakDB
     {
-        static auto clearHashmap = [](void* aHashmap)
-        {
-            auto* pHashMap = reinterpret_cast<HashMap<int, int>*>(aHashmap);
-            pHashMap->GetAllocator()->Free(reinterpret_cast<void*>(pHashMap->nodes));
-            pHashMap->indexTable = nullptr;
-            pHashMap->size = 0;
-            pHashMap->capacity = 0;
-            pHashMap->nodes = 0;
-            pHashMap->unk18 = 0;
-            pHashMap->unk20 = -1;
-            pHashMap->unk24 = 0;
-        };
-
         fakeTweakDB.recordsByType.for_each([](const IRTTIType*, DynArray<Handle<IScriptable>>& array)
             {
                 array.GetAllocator()->Free(array.entries);
             });
 
-        clearHashmap(&fakeTweakDB.recordsByID);
-        clearHashmap(&fakeTweakDB.recordsByType);
+        fakeTweakDB.recordsByID.Clear();
+        fakeTweakDB.recordsByType.Clear();
     }
 
     return updated;

--- a/include/RED4ext/Types/TweakDB-inl.hpp
+++ b/include/RED4ext/Types/TweakDB-inl.hpp
@@ -291,7 +291,7 @@ RED4EXT_INLINE int32_t RED4ext::TweakDB::CreateFlatValue(const CStackType& aStac
                 return -1;
 
             uint32_t currentSize = static_cast<uint32_t>(flatDataBufferEnd - flatDataBuffer);
-            uint32_t newCapacity = flatDataBufferCapacity + (100 * (8 + sizeof(DynArray<int>)));
+            uint32_t newCapacity = flatDataBufferCapacity + (1000 * (8 + sizeof(DynArray<int>)));
             if (newCapacity > 0x00FFFFFF)
             {
                 newCapacity = 0x00FFFFFF;
@@ -316,7 +316,13 @@ RED4EXT_INLINE int32_t RED4ext::TweakDB::CreateFlatValue(const CStackType& aStac
             // Race condition when freeing old buffer
             // Undefined behavior if the game is in the process of dereferencing the buffer
             // Mutex locking is useless. Game accesses the buffer via a static pointer
-            pRTTIAllocator->Free(oldFlatDataBuffer);
+            //pRTTIAllocator->Free(oldFlatDataBuffer);
+
+            // Delay freeing. Consumes more memory but less risky
+            static void* lastFlatDataBuffer = nullptr;
+            if (lastFlatDataBuffer != nullptr)
+                pRTTIAllocator->Free(lastFlatDataBuffer);
+            lastFlatDataBuffer = oldFlatDataBuffer;
         }
 
         if (aStackType.type == pInt32RTTIType)

--- a/include/RED4ext/Types/TweakDB.hpp
+++ b/include/RED4ext/Types/TweakDB.hpp
@@ -75,14 +75,12 @@ struct TweakDB
         virtual bool ToValueOffset_Float(uint32_t* aValueOffset) const = 0;
         virtual bool ToValueOffset_array_Int32(uint32_t* aValueOffset) const = 0;
         virtual bool ToValueOffset_Int32(uint32_t* aValueOffset) const = 0;
-        virtual CStackType* GetValue(CStackType* aStackType) const = 0;
+        virtual CStackType GetValue() const = 0;
 
         template<typename T>
         T* GetValue() const
         {
-            CStackType stackType;
-            GetValue(&stackType);
-            return reinterpret_cast<T*>(stackType.value);
+            return reinterpret_cast<T*>(GetValue().value);
         }
 
         // [Warning] FlatValues are pooled.

--- a/include/RED4ext/Types/TweakDB.hpp
+++ b/include/RED4ext/Types/TweakDB.hpp
@@ -27,7 +27,7 @@ namespace RED4ext
 struct gamedataTweakDBRecord : IScriptable
 {
     virtual void sub_110() = 0; // 110
-    virtual uint32_t GetTweakBaseHash() = 0; // Murmur3
+    virtual uint32_t GetTweakBaseHash() const = 0; // Murmur3
     
     TweakDBID recordID;
 };
@@ -148,15 +148,23 @@ struct TweakDB
     DynArray<TweakDBID> Query(TweakDBID aDBID);
     bool TryQuery(TweakDBID aDBID, DynArray<TweakDBID>& aArray);
 
-    // [Experimental] Updates all the value offsets inside the record
+    // Updates all the value offsets inside the record
     bool UpdateRecord(TweakDBID aDBID);
-    // [Experimental] Updates all the value offsets inside the record
+    // Updates all the value offsets inside the record
     bool UpdateRecord(gamedataTweakDBRecord* aRecord);
+
+    bool CreateRecord(TweakDBID aDBID, IRTTIType* aType);
+    bool CreateRecord(TweakDBID aDBID, uint32_t aTweakBaseHash);
+    bool RemoveRecord(TweakDBID aDBID);
+
+    // TweakDBID must include tdbOffset
+    bool AddFlat(TweakDBID aDBID);
+    bool RemoveFlat(TweakDBID aDBID);
 
     // Multithreads may lead to undefined behavior
     FlatValue* GetFlatValue(TweakDBID aDBID);
     // returns -1 on error, tdbOffset on success
-    int32_t CreateFlat(const CStackType& aStackType);
+    int32_t CreateFlatValue(const CStackType& aStackType);
 
     static TweakDB* Get();
 

--- a/include/RED4ext/Types/TweakDB.hpp
+++ b/include/RED4ext/Types/TweakDB.hpp
@@ -91,6 +91,8 @@ struct TweakDB
         // [Warning] FlatValues are pooled.
         void SetValue(ScriptInstance aValue);
 
+        // Multithreads may lead to undefined behavior
+        // Doesn't/Can't lock mutex in here
         int32_t ToTDBOffset() const;
 
         // value here
@@ -115,7 +117,7 @@ struct TweakDB
     HashMap<CName, FlatValue*> defaultValueByType;                          // E8
     DynArray<CString> unk118;                                               // 118 - empty - maybe not CString
     uintptr_t flatDataBuffer;                                               // 128
-    uint32_t flatDataBufferCapacity;                                            // 130
+    uint32_t flatDataBufferCapacity;                                        // 130
     uintptr_t flatDataBufferEnd;                                            // 138
 
     template<typename T>
@@ -155,8 +157,8 @@ struct TweakDB
 
     // Multithreads may lead to undefined behavior
     FlatValue* GetFlatValue(TweakDBID aDBID);
-    // Multithreads may lead to undefined behavior
-    FlatValue* CreateFlatValue(const CStackType& aStackType);
+    // returns -1 on error, tdbOffset on success
+    int32_t CreateFlat(const CStackType& aStackType);
 
     static TweakDB* Get();
 


### PR DESCRIPTION
added 'reserve/insert/remove/clear' functions to HashMap 
added 'emplace/remove/clear' functions to DynArray
added 'RemoveAt/InsertAt' functions to CArrayBase RTTI
added 'Move' function to IRTTIType
added '[Create/Remove]Record' and '[Add/Remove]Flat' to TweakDB
added != operator to TweakDBID (fixes a bug where it would implicitly cast into u64)
fixed rare race condition in TweakDB::CreateFlatValue by delaying freeing the buffer (buffer can't go over 0xFFFFFF, won't use a lot of memory)

DynArray/HashMap functions were tested and are working
HashMap Insert/Remove were tested with hash-collisioned keys