### PR TITLE
added SpinLock and InsertOrAssign fixes

### DIFF
--- a/include/RED4ext/DynArray.hpp
+++ b/include/RED4ext/DynArray.hpp
@@ -52,7 +52,7 @@ struct DynArray
     template<class... TArgs>
     void Emplace(T* aPosition, TArgs&&... aArgs)
     {
-        uint32_t posIdx = aPosition - begin();
+        uint32_t posIdx = static_cast<uint32_t>(aPosition - begin());
         uint32_t newSize = size + 1;
         if (newSize > capacity)
         {

--- a/include/RED4ext/HashMap.hpp
+++ b/include/RED4ext/HashMap.hpp
@@ -204,7 +204,7 @@ struct HashMap
         std::pair<T*, bool> pair = Emplace(aKey, std::forward<const T&>(aValue));
         if (!pair.second)
         {
-            pair.first = aValue;
+            *pair.first = aValue;
         }
         return pair;
     }
@@ -214,7 +214,7 @@ struct HashMap
         std::pair<T*, bool> pair = Emplace(aKey, std::forward<T&&>(aValue));
         if (!pair.second)
         {
-            pair.first = std::move(aValue);
+            *pair.first = std::move(aValue);
         }
         return pair;
     }
@@ -282,7 +282,7 @@ struct HashMap
         if (aSize <= capacity)
             return;
 
-        size_t requiredBytes = aSize * (sizeof(Node) + 4 /* *indexTable */);
+        uint32_t requiredBytes = aSize * (sizeof(Node) + 4 /* *indexTable */);
         auto allocResult = GetAllocator()->AllocAligned(requiredBytes, 8);
         memset(allocResult.memory, 0, allocResult.size);
         NodeList newNodeList(reinterpret_cast<Node*>(allocResult.memory), aSize);

--- a/include/RED4ext/Map.hpp
+++ b/include/RED4ext/Map.hpp
@@ -76,7 +76,7 @@ struct Map
         std::pair<T*, bool> pair = Emplace(std::forward<const K&>(aKey), std::forward<const T&>(aValue));
         if (!pair.second)
         {
-            pair.first = aValue;
+            *pair.first = aValue;
         }
         return pair;
     }
@@ -86,7 +86,7 @@ struct Map
         std::pair<T*, bool> pair = Emplace(std::forward<const K&>(aKey), std::forward<T&&>(aValue));
         if (!pair.second)
         {
-            pair.first = std::move(aValue);
+            *pair.first = std::move(aValue);
         }
         return pair;
     }

--- a/include/RED4ext/Types/SharedMutex-inl.hpp
+++ b/include/RED4ext/Types/SharedMutex-inl.hpp
@@ -9,6 +9,11 @@
 
 #include <Windows.h>
 
+RED4EXT_INLINE RED4ext::SharedMutex::SharedMutex()
+    : state(0)
+{
+}
+
 RED4EXT_INLINE bool RED4ext::SharedMutex::TryLock()
 {
     return _InterlockedCompareExchange8(&state, -1, 0) == 0;

--- a/include/RED4ext/Types/SharedMutex-inl.hpp
+++ b/include/RED4ext/Types/SharedMutex-inl.hpp
@@ -4,6 +4,11 @@
 #include <RED4ext/Types/SharedMutex.hpp>
 #endif
 
+#include <cstdint>
+#include <intrin.h>
+
+#include <Windows.h>
+
 RED4EXT_INLINE bool RED4ext::SharedMutex::TryLock()
 {
     return _InterlockedCompareExchange8(&state, -1, 0) == 0;
@@ -17,7 +22,6 @@ RED4EXT_INLINE void RED4ext::SharedMutex::Lock()
         if (TryLock())
             break;
 
-        // The following is not required but prefered
         ++loopCount;
         if (loopCount == 0x4000)
             loopCount = 0;
@@ -28,7 +32,7 @@ RED4EXT_INLINE void RED4ext::SharedMutex::Lock()
 
 RED4EXT_INLINE void RED4ext::SharedMutex::Unlock()
 {
-    state = 0;
+    InterlockedExchange8(&state, 0);
 }
 
 RED4EXT_INLINE bool RED4ext::SharedMutex::TryLockShared()
@@ -49,7 +53,6 @@ RED4EXT_INLINE void RED4ext::SharedMutex::LockShared()
         if (TryLockShared())
             break;
 
-        // The following is not required but prefered
         ++loopCount;
         if (loopCount == 0x4000)
             loopCount = 0;

--- a/include/RED4ext/Types/SharedMutex.hpp
+++ b/include/RED4ext/Types/SharedMutex.hpp
@@ -1,8 +1,4 @@
 #pragma once
-#include <memory>
-
-#include <Windows.h>
-
 #include <RED4ext/Common.hpp>
 
 namespace RED4ext
@@ -34,6 +30,7 @@ struct SharedMutex
     void lock_shared();
     void unlock_shared();
 };
+RED4EXT_ASSERT_SIZE(SharedMutex, 1);
 }
 
 #ifdef RED4EXT_HEADER_ONLY

--- a/include/RED4ext/Types/SharedMutex.hpp
+++ b/include/RED4ext/Types/SharedMutex.hpp
@@ -8,7 +8,13 @@ struct SharedMutex
     // -1 : write
     // 0 : free
     // + : read
-    volatile char state = 0;
+    volatile char state;
+
+    SharedMutex();
+    SharedMutex(const SharedMutex&) = delete;
+    SharedMutex(SharedMutex&&) = delete;
+    SharedMutex& operator=(const SharedMutex&) = delete;
+    SharedMutex& operator=(SharedMutex&&) = delete;
 
     bool TryLock();
     void Lock();

--- a/include/RED4ext/Types/SpinLock-inl.hpp
+++ b/include/RED4ext/Types/SpinLock-inl.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/Types/SpinLock.hpp>
+#endif
+
+#include <cstdint>
+
+#include <Windows.h>
+
+RED4EXT_INLINE bool RED4ext::SpinLock::TryLock()
+{
+    return InterlockedExchange8(&state, 1) == 0;
+}
+
+RED4EXT_INLINE void RED4ext::SpinLock::Lock()
+{
+    uint32_t loopCount = 0;
+    while (true)
+    {
+        if (TryLock())
+            break;
+
+        if (loopCount >= 16)
+            SwitchToThread();
+        ++loopCount;
+    }
+}
+
+RED4EXT_INLINE void RED4ext::SpinLock::Unlock()
+{
+    InterlockedExchange8(&state, 0);
+}
+
+// ----------------------------
+// -- support for lock_guard --
+// ----------------------------
+
+RED4EXT_INLINE bool RED4ext::SpinLock::try_lock()
+{
+    return TryLock();
+}
+
+RED4EXT_INLINE void RED4ext::SpinLock::lock()
+{
+    Lock();
+}
+
+RED4EXT_INLINE void RED4ext::SpinLock::unlock()
+{
+    Unlock();
+}

--- a/include/RED4ext/Types/SpinLock-inl.hpp
+++ b/include/RED4ext/Types/SpinLock-inl.hpp
@@ -8,6 +8,11 @@
 
 #include <Windows.h>
 
+RED4EXT_INLINE RED4ext::SpinLock::SpinLock()
+    : state(0)
+{
+}
+
 RED4EXT_INLINE bool RED4ext::SpinLock::TryLock()
 {
     return InterlockedExchange8(&state, 1) == 0;

--- a/include/RED4ext/Types/SpinLock.hpp
+++ b/include/RED4ext/Types/SpinLock.hpp
@@ -7,7 +7,13 @@ struct SpinLock
 {
     // 0 : free
     // 1 : locked
-    volatile char state = 0;
+    volatile char state;
+
+    SpinLock();
+    SpinLock(const SpinLock&) = delete;
+    SpinLock(SpinLock&&) = delete;
+    SpinLock& operator=(const SpinLock&) = delete;
+    SpinLock& operator=(SpinLock&&) = delete;
 
     bool TryLock();
     void Lock();

--- a/include/RED4ext/Types/SpinLock.hpp
+++ b/include/RED4ext/Types/SpinLock.hpp
@@ -1,0 +1,29 @@
+#pragma once
+#include <RED4ext/Common.hpp>
+
+namespace RED4ext
+{
+struct SpinLock
+{
+    // 0 : free
+    // 1 : locked
+    volatile char state = 0;
+
+    bool TryLock();
+    void Lock();
+    void Unlock();
+
+    // ----------------------------
+    // -- support for lock_guard --
+    // ----------------------------
+
+    bool try_lock();
+    void lock();
+    void unlock();
+};
+RED4EXT_ASSERT_SIZE(SpinLock, 1);
+}
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/Types/SpinLock-inl.hpp>
+#endif

--- a/src/Types/SpinLock.cpp
+++ b/src/Types/SpinLock.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/Types/SpinLock-inl.hpp>


### PR DESCRIPTION
https://github.com/WopsS/RED4ext.SDK/blob/1e5a843715e8e61ec6b8989d5bbe8ede8b648430/include/RED4ext/SortedArray.hpp#L61-L69
'SortedUniqueArray' had an issue. 'aItem' would be in an "unspecified" state because 'Emplace' has moved it
Fixed by changing it to this:
https://github.com/WopsS/RED4ext.SDK/blob/1737fe23493358e81d74514dc38861e082e8dfb9/include/RED4ext/SortedArray.hpp#L56-L59
https://github.com/WopsS/RED4ext.SDK/blob/1737fe23493358e81d74514dc38861e082e8dfb9/include/RED4ext/SortedArray.hpp#L182-L203