### PR TITLE
Improve Variant

### DIFF
--- a/include/RED4ext/Types/SimpleTypes-inl.hpp
+++ b/include/RED4ext/Types/SimpleTypes-inl.hpp
@@ -5,6 +5,7 @@
 #endif
 
 #include <RED4ext/REDhash.hpp>
+#include <RED4ext/RTTITypes.hpp>
 
 RED4EXT_INLINE RED4ext::TweakDBID::TweakDBID(uint64_t aValue) noexcept
     : value(aValue)
@@ -99,4 +100,15 @@ RED4EXT_INLINE bool RED4ext::TweakDBID::operator==(const TweakDBID& aDBID) const
 RED4EXT_INLINE bool RED4ext::TweakDBID::operator!=(const TweakDBID& aDBID) const noexcept
 {
     return !(aDBID == *this);
+}
+
+RED4EXT_INLINE RED4ext::Variant::Variant(IRTTIType* aType, ScriptInstance aValue)
+    : type(reinterpret_cast<uint64_t>(aType))
+    , instance(aValue)
+{
+    if (aType->GetSize() <= 16 && aType->GetAlignment() <= 8)
+    {
+        memcpy(inlinedBuf, instance, aType->GetSize());
+        type |= 1;
+    }
 }

--- a/include/RED4ext/Types/SimpleTypes.hpp
+++ b/include/RED4ext/Types/SimpleTypes.hpp
@@ -96,26 +96,24 @@ RED4EXT_ASSERT_SIZE(EditorObjectID, 0x20);
 struct Variant
 {
     Variant() = default;
+    
+    Variant(IRTTIType* aType, ScriptInstance aValue);
 
-    Variant(uint64_t aType, uint64_t aValue)
-        : type(aType)
-        , value(aValue)
-        , unknown(0)
+    uint64_t type { 0 }; // 00
+    union                
     {
-    }
-
-    Variant(IRTTIType* aType, ScriptInstance aValue)
-        : type(reinterpret_cast<std::uintptr_t>(aType))
-        , value(reinterpret_cast<std::uintptr_t>(aValue))
-        , unknown(0)
-    {
-    }
-
-    int64_t type;  // 00
-    int64_t value; // 08
-    int64_t unknown; // 10
+        struct
+        {
+            ScriptInstance instance; // 08
+            uint64_t       unknown;  // 10
+        };
+        char inlinedBuf[16]; // 08
+    };  
 };
 RED4EXT_ASSERT_SIZE(Variant, 0x18);
+RED4EXT_ASSERT_OFFSET(Variant, instance, 0x08);
+RED4EXT_ASSERT_OFFSET(Variant, unknown, 0x10);
+RED4EXT_ASSERT_OFFSET(Variant, inlinedBuf, 0x08);
 
 struct DataBuffer
 {


### PR DESCRIPTION
Modified structure according to what was discussed before.
Added some extra checks in regards to placement of things.

These should be working ToVariant/FromVariant functions we have in CET, needs testing...
I could include them if you want, just tell me where to put them and I'll remake them for this x) 

```cpp
    aLuaGlobal["ToVariant"] = [this](Type& aInstance) -> sol::object {
        auto* pType = aInstance.GetType();
        auto* pHandle = aInstance.GetHandle();

        if (!pType || !pHandle)
            return sol::nil;

        auto lockedState = m_lua.Lock();
        auto& luaState = lockedState.Get();

        return sol::object(luaState, sol::in_place, Variant(pType, pHandle));
    };

    aLuaGlobal["FromVariant"] = [this](Variant& aVariant) -> sol::object {
        if (aVariant.type == 0)
            return sol::nil;

        RED4ext::CStackType result;
        if ((aVariant.type & 1) == 0)
        {
            result.type = reinterpret_cast<RED4ext::IRTTIType*>(aVariant.type); 
            result.value = aVariant.instance;
        }
        else
        {
            result.type = reinterpret_cast<RED4ext::IRTTIType*>(aVariant.type & (~1ull));
            result.value = &aVariant.inlinedBuf;
        }

        auto lockedState = m_lua.Lock();
        
        return Scripting::ToLua(lockedState, result);
    };
```