### PR TITLE
Added some Get methods to RTTISystem

### DIFF
--- a/include/RED4ext/RTTISystem.hpp
+++ b/include/RED4ext/RTTISystem.hpp
@@ -24,14 +24,14 @@ struct IRTTISystem
     virtual void sub_28() = 0;                                                                 // 28
     virtual CGlobalFunction* GetFunction(CName aName) = 0;                                     // 30
     virtual void sub_38() = 0;                                                                 // 38
-    virtual void sub_40() = 0;                                                                 // 40
-    virtual void sub_48() = 0;                                                                 // 48
+    virtual void GetNativeTypes(DynArray<IRTTIType*> &aTypes) = 0;                             // 40
+    virtual void GetGlobalFunctions(DynArray<CGlobalFunction*>& aFunctions) = 0;               // 48
     virtual void sub_50() = 0;                                                                 // 50
-    virtual void sub_58() = 0;                                                                 // 58
-    virtual void sub_60() = 0;                                                                 // 60
-    virtual void sub_68() = 0;                                                                 // 68
-    virtual void sub_70() = 0;                                                                 // 70
-    virtual void sub_78() = 0;                                                                 // 78
+    virtual void GetClassFunctions(DynArray<CGlobalFunction*>& aFunctions) = 0;                // 58
+    virtual void GetEnums(DynArray<CEnum*>& aEnums, bool aScriptedOnly = false) = 0;           // 60
+    virtual void GetBitFields(DynArray<CBitfield*>& aBitFields, bool aScriptedOnly = false) = 0; // 68
+    virtual void GetClasses(CClass* aIsAClass, DynArray<CClass*>& aClasses, bool aFilter(CClass*) = nullptr, bool aIncludeAbstract = false) = 0; // 70
+    virtual void GetDerivedClasses(CClass* aBaseClass, DynArray<CClass*>& aClasses) = 0;       // 78
     virtual bool RegisterType(IRTTIType* aType, uint32_t aAsyncId) = 0;                        // 80
     virtual void sub_88() = 0;                                                                 // 88
     virtual void sub_90() = 0;                                                                 // 90

--- a/include/RED4ext/RTTISystem.hpp
+++ b/include/RED4ext/RTTISystem.hpp
@@ -20,7 +20,7 @@ struct IRTTISystem
     virtual IRTTIType* GetTypeByAsyncId(uint32_t aAsyncId) = 0;                                // 08
     virtual CClass* GetClass(CName aName) = 0;                                                 // 10
     virtual CEnum* GetEnum(CName aName) = 0;                                                   // 18
-    virtual CBitfield* GetBitField(CName aName) = 0;                                           // 20
+    virtual CBitfield* GetBitfield(CName aName) = 0;                                           // 20
     virtual void sub_28() = 0;                                                                 // 28
     virtual CGlobalFunction* GetFunction(CName aName) = 0;                                     // 30
     virtual void sub_38() = 0;                                                                 // 38
@@ -29,7 +29,7 @@ struct IRTTISystem
     virtual void sub_50() = 0;                                                                 // 50
     virtual void GetClassFunctions(DynArray<CGlobalFunction*>& aFunctions) = 0;                // 58
     virtual void GetEnums(DynArray<CEnum*>& aEnums, bool aScriptedOnly = false) = 0;           // 60
-    virtual void GetBitFields(DynArray<CBitfield*>& aBitFields, bool aScriptedOnly = false) = 0; // 68
+    virtual void GetBitfields(DynArray<CBitfield*>& aBitfields, bool aScriptedOnly = false) = 0; // 68
     virtual void GetClasses(CClass* aIsAClass, DynArray<CClass*>& aClasses, bool aFilter(CClass*) = nullptr, bool aIncludeAbstract = false) = 0; // 70
     virtual void GetDerivedClasses(CClass* aBaseClass, DynArray<CClass*>& aClasses) = 0;       // 78
     virtual bool RegisterType(IRTTIType* aType, uint32_t aAsyncId) = 0;                        // 80

--- a/include/RED4ext/RTTITypes.hpp
+++ b/include/RED4ext/RTTITypes.hpp
@@ -184,10 +184,17 @@ RED4EXT_ASSERT_SIZE(CLegacySingleChannelCurve, 0x48);
 
 struct CBitfield : CRTTIType
 {
+    struct Flags
+    {
+        uint8_t isScripted : 1; // 00
+        uint8_t b2 : 7;
+    };
+    RED4EXT_ASSERT_SIZE(CBitfield::Flags, 0x01);
+
     CName hash;         // 10
     CName unk18;        // 18
     uint8_t size;       // 20 - Size in bytes the instance will use
-    uint8_t flags;      // 21
+    Flags flags;        // 21
     uint16_t unk22;     // 22
     uint32_t unk24;     // 24
     uint64_t validBits; // 28
@@ -276,10 +283,17 @@ RED4EXT_ASSERT_OFFSET(CClass, unkE0, 0xE0);
 
 struct CEnum : CRTTIType
 {
+    struct Flags
+    {
+        uint8_t isScripted : 1;    // 00
+        uint8_t b2 : 7;
+    };
+    RED4EXT_ASSERT_SIZE(CEnum::Flags, 0x01);
+
     CName hash;                   // 10
     CName unk18;                  // 18
     uint8_t size;                 // 20 - Size in bytes the instance will use
-    uint8_t flags;                // 21
+    Flags flags;                  // 21
     uint16_t unk22;               // 22
     uint32_t unk24;               // 24
     DynArray<CName> hashList;     // 28


### PR DESCRIPTION
Filled out several of the RTTISystem methods that return lists of specific types.

The Enum and Bitfield variants take a boolean that checks the first bit of their flags byte, which filters whether they are scripted or native. I've tested that it works that way for Enums, but Bitfields are only implemented as native code and the redscript compiler doesn't currently support bitfields, so it's purely conjecture on my part (they are treated identically though).

There are a few differences between `IRTTISystem::GetClasses()` and `IRTTISystem::GetDerivedClasses()`:
 - `GetClasses()` will call `CClass::IsA(aIsAClass)` on each class if `aIsAClass` is not null. 
 - `GetClasses()` has an optional filter function that is called on each matching class
 - `GetDerivedClasses()` will check each class to see if `class.parent == aBaseClass`