### PR TITLE
Native func support

### DIFF
--- a/include/RED4ext/Addresses.hpp
+++ b/include/RED4ext/Addresses.hpp
@@ -78,6 +78,10 @@ constexpr uintptr_t CNamePool_AddPair = 0x1401CDF40 - ImageBase; // 48 83 EC 38 
 constexpr uintptr_t CNamePool_Get = 0x1401CDAB0 - ImageBase; // 48 83 EC 38 48 8B 11 48 8D 4C 24 20 E8, expected: 1, index: 0
 #pragma endregion
 
+#pragma region CRTTIRegistrator
+constexpr uintptr_t CRTTIRegistrator_Add = 0x1401D0A40 - ImageBase; // 48 89 5C 24 08 48 89 74 24 20 4C 89 44 24 18 48 89 54 24 10 57 48 83 EC 50 48 8B F1, expected: 1, index: 0
+#pragma endregion
+
 #pragma region CRTTIScriptReferenceType
 constexpr uintptr_t CRTTIScriptReferenceType_ctor = 0x14023A400 - ImageBase; // 48 89 5C 24 18 57 48 83 EC 20 48 8B FA 48 8B D9 E8 ? ? ? ? 48 8D 05 , expected: 1, index: 0
 constexpr uintptr_t CRTTIScriptReferenceType_Set = 0x14023B960 - ImageBase; // 48 89 5C 24 20 57 48 83  EC 20 4C 89 41 18 48 8B, expected: 1, index: 0

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -118,13 +118,19 @@ struct Variant
 };
 RED4EXT_ASSERT_SIZE(Variant, 0x18);
 
+struct RawBuffer
+{
+    void* data;         // 00
+    uint32_t size;      // 08
+    uint32_t alignment; // 0C
+    Unk530 unk10;       // 10
+};
+RED4EXT_ASSERT_SIZE(RawBuffer, 0x20);
+
 struct DataBuffer
 {
-    int64_t unk00; // 00
-    int32_t unk08; // 08
-    int32_t unk0C; // 0C
-    Unk530 unk10;  // 10
-    int64_t unk20; // 20
+    RawBuffer buffer; // 00
+    uint64_t unk20;   // 20 - Pointer to something
 };
 RED4EXT_ASSERT_SIZE(DataBuffer, 0x28);
 
@@ -138,9 +144,7 @@ struct DeferredDataBuffer
 {
     int64_t unk00; // 00
     int64_t unk08; // 08
-    int64_t unk10; // 10
-    int64_t unk18; // 18
-    Unk530 unk20;  // 20
+    RawBuffer buffer; // 10
     int64_t unk30; // 30
     int8_t unk38;  // 38
     int64_t unk40; // 40

--- a/include/RED4ext/RTTISystem-inl.hpp
+++ b/include/RED4ext/RTTISystem-inl.hpp
@@ -12,3 +12,13 @@ RED4EXT_INLINE RED4ext::CRTTISystem* RED4ext::CRTTISystem::Get()
     RelocFunc<CRTTISystem* (*)()> func(Addresses::CRTTISystem_Get);
     return func();
 }
+
+RED4EXT_INLINE void RED4ext::RTTIRegistrator::Add(CallbackFunc aRegFunc, CallbackFunc aPostRegFunc, bool aUnused)
+{
+    static RTTIRegistrator instance;
+
+    using func_t = RTTIRegistrator* (*)(RTTIRegistrator*, CallbackFunc, CallbackFunc, bool);
+
+    RelocFunc<func_t> func(Addresses::CRTTIRegistrator_Add);
+    func(&instance, aRegFunc, aPostRegFunc, aUnused);
+}

--- a/include/RED4ext/RTTISystem.hpp
+++ b/include/RED4ext/RTTISystem.hpp
@@ -25,9 +25,9 @@ struct IRTTISystem
     virtual CGlobalFunction* GetFunction(CName aName) = 0;                                       // 30
     virtual void sub_38() = 0;                                                                   // 38
     virtual void GetNativeTypes(DynArray<CBaseRTTIType*>& aTypes) = 0;                           // 40
-    virtual void GetGlobalFunctions(DynArray<CGlobalFunction*>& aFunctions) = 0;                 // 48
+    virtual void GetGlobalFunctions(DynArray<CBaseFunction*>& aFunctions) = 0;                   // 48
     virtual void sub_50() = 0;                                                                   // 50
-    virtual void GetClassFunctions(DynArray<CGlobalFunction*>& aFunctions) = 0;                  // 58
+    virtual void GetClassFunctions(DynArray<CBaseFunction*>& aFunctions) = 0;                    // 58
     virtual void GetEnums(DynArray<CEnum*>& aEnums, bool aScriptedOnly = false) = 0;             // 60
     virtual void GetBitfields(DynArray<CBitfield*>& aBitfields, bool aScriptedOnly = false) = 0; // 68
     virtual void GetClasses(CClass* aIsAClass, DynArray<CClass*>& aClasses, bool (*aFilter)(CClass*) = nullptr,
@@ -35,9 +35,9 @@ struct IRTTISystem
     virtual void GetDerivedClasses(CClass* aBaseClass, DynArray<CClass*>& aClasses) = 0;      // 78
     virtual void RegisterType(CBaseRTTIType* aType, uint32_t aAsyncId) = 0;                   // 80
     virtual void sub_88() = 0;                                                                // 88
-    virtual void sub_90() = 0;                                                                // 90
+    virtual void UnregisterType(CBaseRTTIType* aType) = 0;                                    // 90
     virtual void RegisterFunction(CGlobalFunction* aFunc) = 0;                                // 98
-    virtual void sub_A0() = 0;                                                                // A0
+    virtual void UnregisterFunction(CGlobalFunction* aFunc) = 0;                              // A0
     virtual void sub_A8() = 0;                                                                // A8
     virtual void sub_B0() = 0;                                                                // B0
     virtual void sub_B8() = 0;                                                                // B8
@@ -73,7 +73,7 @@ struct CRTTISystem : IRTTISystem
     HashMap<uint64_t, CBaseRTTIType*> typesByAsyncId; // 40
     HashMap<CName, uint32_t> typeAsyncIds;            // 70
     HashMap<CName, CGlobalFunction*> funcs;           // A0
-    HashMap<void*, void*> unkD0;                      // D0
+    HashMap<uint64_t, CGlobalFunction*> funcsByHash;  // D0
     HashMap<void*, void*> unkF8;                      // F8
     DynArray<void*> unk130;                           // 130
     DynArray<void*> unk140;                           // 140
@@ -91,6 +91,15 @@ RED4EXT_ASSERT_OFFSET(CRTTISystem, types, 0x10);
 RED4EXT_ASSERT_OFFSET(CRTTISystem, funcs, 0xA0);
 RED4EXT_ASSERT_OFFSET(CRTTISystem, scriptToNative, 0x150);
 RED4EXT_ASSERT_OFFSET(CRTTISystem, nativeToScript, 0x180);
+
+struct RTTIRegistrator
+{
+    typedef void (*CallbackFunc)(void);
+
+    static void Add(CallbackFunc aRegFunc, CallbackFunc aPostRegFunc, bool aUnused = true);
+};
+RED4EXT_ASSERT_SIZE(RTTIRegistrator, 0x01);
+
 } // namespace RED4ext
 
 #ifdef RED4EXT_HEADER_ONLY

--- a/include/RED4ext/Scripting/Functions.hpp
+++ b/include/RED4ext/Scripting/Functions.hpp
@@ -6,6 +6,7 @@
 #include <RED4ext/HashMap.hpp>
 #include <RED4ext/Memory/Allocators.hpp>
 #include <RED4ext/InstanceType.hpp>
+#include <RED4ext/Scripting/Script.hpp>
 
 namespace RED4ext
 {
@@ -81,7 +82,7 @@ struct CBaseFunction : IFunction
     DynArray<CProperty*> params;    // 28
     DynArray<CProperty*> localVars; // 38
     HashMap<uint64_t, void*> unk48; // 48
-    int8_t unk78[48];               // 78
+    CCompiledCode bytecode;         // 78
     Flags flags;                    // A8
     int32_t unkAC;                  // AC
 
@@ -94,7 +95,8 @@ private:
     bool ExecuteNative(CStack* aStack, CStackFrame& aFrame);
 };
 RED4EXT_ASSERT_SIZE(CBaseFunction, 0xB0);
-RED4EXT_ASSERT_OFFSET(CBaseFunction, fullName, 0x8);
+RED4EXT_ASSERT_OFFSET(CBaseFunction, fullName, 0x08);
+RED4EXT_ASSERT_OFFSET(CBaseFunction, bytecode, 0x78);
 RED4EXT_ASSERT_OFFSET(CBaseFunction, flags, 0xA8);
 
 struct CGlobalFunction : CBaseFunction

--- a/include/RED4ext/Scripting/Script-inl.hpp
+++ b/include/RED4ext/Scripting/Script-inl.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/Scripting/Script.hpp>
+#endif

--- a/include/RED4ext/Scripting/Script.cpp
+++ b/include/RED4ext/Scripting/Script.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/Scripting/Script-inl.hpp>

--- a/include/RED4ext/Scripting/Script.hpp
+++ b/include/RED4ext/Scripting/Script.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <RED4ext/NativeTypes.hpp>
+#include <RED4ext/Map.hpp>
+
+namespace RED4ext
+{
+
+struct CCompiledCode
+{
+    uint32_t unk00;      // 00
+    uint32_t unk04;      // 04
+    DataBuffer bytecode; // 08
+};
+RED4EXT_ASSERT_SIZE(CCompiledCode, 0x30);
+RED4EXT_ASSERT_OFFSET(CCompiledCode, bytecode, 0x08);
+
+} // namespace RED4ext
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/Scripting/Script-inl.hpp>
+#endif

--- a/scripts/patterns.py
+++ b/scripts/patterns.py
@@ -97,6 +97,10 @@ def get_groups() -> List[Group]:
             Item(name='Get', pattern='48 83 EC 38 48 8B 11 48 8D 4C 24 20 E8')
         ]),
 
+        Group(name='CRTTIRegistrator', functions=[
+            Item(name='Add', pattern='48 89 5C 24 08 48 89 74 24 20 4C 89 44 24 18 48 89 54 24 10 57 48 83 EC 50 48 8B F1')
+        ]),
+
         Group(name='CRTTISystem', functions=[
             Item(name='Get', pattern='40 53 48 83 EC 20 65 48 8B 04 25 58 00 00 00 48 8D 1D ? ? ? ?')
         ]),


### PR DESCRIPTION
Added a hook to the `RTTIRegistrator` constructor to add callback functions that are called before the `final.redscripts` is loaded, allowing for new native methods to be defined in RED4ext and called from Redscript.

`RTTIRegistrator::Add()` can be called immediately after the dll attaches:
```cpp
RED4EXT_C_EXPORT void RED4EXT_CALL RegisterTypes() {}
RED4EXT_C_EXPORT void RED4EXT_CALL PostRegisterTypes() {}

BOOL APIENTRY DllMain(HMODULE aModule, DWORD aReason, LPVOID aReserved)
{
    switch (aReason)
    {
    case DLL_PROCESS_ATTACH:
        DisableThreadLibraryCalls(aModule);
        RED4ext::RTTIRegistrator::Add(RegisterTypes, PostRegisterTypes);
        break;
    }

    return TRUE;
}
```


Also fleshed out one of the unknown chunks in the `CBaseFunction` class: a `DataBuffer` to the compiled redscript bytecode