### PR TITLE
Background jobs and callbacks

### DIFF
--- a/include/RED4ext/Addresses.hpp
+++ b/include/RED4ext/Addresses.hpp
@@ -160,15 +160,9 @@ constexpr uintptr_t OpcodeHandlers_Get = 0x1401C0D6D - ImageBase; // 4C 8D 15 ? 
 #pragma endregion
 
 #pragma region ResourceLoader
-constexpr uintptr_t ResourceLoader =
-    0x143E15568 -
-    ImageBase; // 48 8B 87 ? ? ? ? 48 8B 5C 24 ? 48 89 05 ? ? ? ? 48 83 C4 20 5F C3, expected: 1, index: 0, offset: 15
-constexpr uintptr_t ResourceLoader_FindToken =
-    0x1401FD400 - ImageBase; // 48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F1 49 8B D8 48 83 C1
-                             // 40 48 8B EA E8, expected: 1, index: 0
-constexpr uintptr_t ResourceLoader_LoadAsync =
-    0x1401FDCD0 - ImageBase; // 4C 8B DC 49 89 5B 10 49 89 6B 18 49 89 73 20 57 48 83 EC 50 48 8B 69 48 33 C0 49 C7 43
-                             // D8 00 00 00 00, expected: 1, index: 0
+constexpr uintptr_t ResourceLoader = 0x143E15568 - ImageBase; // 48 8B 87 ? ? ? ? 48 8B 5C 24 ? 48 89 05 ? ? ? ? 48 83 C4 20 5F C3, expected: 1, index: 0, offset: 15
+constexpr uintptr_t ResourceLoader_FindToken = 0x1401FD400 - ImageBase; // 48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 48 8B F1 49 8B D8 48 83 C1 40 48 8B EA E8, expected: 1, index: 0
+constexpr uintptr_t ResourceLoader_LoadAsync = 0x1401FDCD0 - ImageBase; // 4C 8B DC 49 89 5B 10 49 89 6B 18 49 89 73 20 57 48 83 EC 50 48 8B 69 48 33 C0 49 C7 43 D8 00 00 00 00, expected: 1, index: 0
 #pragma endregion
 
 #pragma region ResourceReference
@@ -178,11 +172,9 @@ constexpr uintptr_t ResourceReference_Reset = 0x140247C80 - ImageBase; // 48 83 
 #pragma endregion
 
 #pragma region ResourceToken
-constexpr uintptr_t ResourceToken_dtor =
-    0x140246290 - ImageBase; // 48 89 5C 24 10 57 48 83 EC 20 8B 41 58 48 8B D9 85 C0 74, expected: 1, index: 0
-constexpr uintptr_t ResourceToken_Fetch =
-    0x1402476B0 -
-    ImageBase; // 40 53 48 83 EC 40 8B 41 58 48 8B D9 0F 29 74 24 30 0F 29 7C 24 20 85 C0 74 0A, expected: 1, index: 0
+constexpr uintptr_t ResourceToken_dtor = 0x140246290 - ImageBase; // 48 89 5C 24 10 57 48 83 EC 20 8B 41 58 48 8B D9 85 C0 74, expected: 1, index: 0
+constexpr uintptr_t ResourceToken_Fetch = 0x1402476B0 - ImageBase; // 40 53 48 83 EC 40 8B 41 58 48 8B D9 0F 29 74 24 30 0F 29 7C 24 20 85 C0 74 0A, expected: 1, index: 0
+constexpr uintptr_t ResourceToken_OnLoaded = 0x140246DA0 - ImageBase; // 40 55 53 56 57 41 56 48 8D 6C 24 C9 48 81 EC F0 00 00 00 48 8B 41 08 0F 57 C0 49 8B F8 4C 8B F2, expected: 1, index: 0
 #pragma endregion
 
 #pragma region Streams

--- a/include/RED4ext/Addresses.hpp
+++ b/include/RED4ext/Addresses.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 
 // Addresses for Cyberpunk 2077, version 1.52.
+// clang-format off
 namespace RED4ext::Addresses
 {
 constexpr uintptr_t ImageBase = 0x140000000;
@@ -194,3 +195,4 @@ constexpr uintptr_t TweakDB_FlatArrayInt32ValueVftable = 0x140F0FEE1 - ImageBase
 constexpr uintptr_t TweakDB_CreateRecord = 0x140FABA00 - ImageBase; // 48 89 5C 24 08 ? 89 ? 24 18 57 48 83 EC 30 8B C2, expected: 1, index: 0
 #pragma endregion
 } // namespace RED4ext::Addresses
+// clang-format on

--- a/include/RED4ext/Addresses.hpp
+++ b/include/RED4ext/Addresses.hpp
@@ -125,6 +125,25 @@ constexpr uintptr_t ISerializable_sub_A0 = 0x1401B5B50 - ImageBase; // 48 83 EC 
 constexpr uintptr_t ISerializable_sub_C0 = 0x1401AB930 - ImageBase; // 40 53 48 83 EC ? 48 8B DA E8 ? ? ? ?, expected: 115, index: 1
 #pragma endregion
 
+#pragma region JobHandle
+constexpr uintptr_t JobHandle_ctor = 0x142BB64F0 - ImageBase; // 40 53 48 83 EC 20 0F B7 02 48 8B D9 48 8B 0D ? ? ? ? 4D 8B C8 66 89 44 24 30 4C 8D 44 24 30, expected: 1, index: 0
+constexpr uintptr_t JobHandle_dtor = 0x142BB6530 - ImageBase; // 40 53 48 83 EC 20 48 8B 11 48 8B D9 48 85 D2 74 13 48 8B 0D ? ? ? ? E8 ? ? ? ?, expected: 1, index: 0
+constexpr uintptr_t JobHandle_Join = 0x142BB6560 - ImageBase; // 48 89 5C 24 08 57 48 83 EC 40 48 8B FA 48 8B D9 48 8B 12 48 8B 0D ? ? ? ? E8 ? ? ? ?, expected: 1, index: 0
+#pragma endregion
+
+#pragma region JobInternals
+constexpr uintptr_t JobInternals_SetLocalThreadParam = 0x142BB8010 - ImageBase; // 8B 15 ? ? ? ? 65 48 8B 04 25 58 00 00 00 41 B8 ? ? ? ? 48 8B 04 D0 41 88 0C 00 C3, expected: 4, index: 2
+constexpr uintptr_t JobInternals_DispatchJob = 0x142BB7E60 - ImageBase; // 4D 8B 08 4C 8B 02 48 8B D1 48 8B 0D ? ? ? ? E9 ? ? ? ?, expected: 2, index: 0
+#pragma endregion
+
+#pragma region JobQueue
+constexpr uintptr_t JobQueue_ctor_FromGroup = 0x142BB8030 - ImageBase; // 48 89 5C 24 10 48 89 6C 24 18 56 57 41 54 41 56 41 57 48 83 EC 20 0F B7 7A 30 4C 8B F1, expected: 1, index: 0
+constexpr uintptr_t JobQueue_ctor_FromParams = 0x142BB8110 - ImageBase; // 48 89 5C 24 10 48 89 6C 24 18 56 57 41 56 48 83 EC 20 48 8D 05 ? ? ? ? 49 8B D8 48 89 01, expected: 1, index: 0
+constexpr uintptr_t JobQueue_dtor = 0x142BB81D0 - ImageBase; // 40 53 48 83 EC 20 80 79 30 00 48 8B D9 75 ? E8 ? ? ? ? 48 8D 4B 18 E8 ? ? ? ? 48 8D 4B 10, expected: 1, index: 0
+constexpr uintptr_t JobQueue_Capture = 0x142BB8280 - ImageBase; // 48 89 5C 24 18 57 48 83  EC 20 48 8B FA 48 8B D9 E8 ? ? ? ? 48 8D 53 10 48 8B CF E8, expected: 1, index: 0
+constexpr uintptr_t JobQueue_SyncWait = 0x142BB8200 - ImageBase; // 48 89 5C 24 18 57 48 83 EC 20 48 8B D9 48 83 C1 18 E8 ? ? ? ? 84 C0 75 ? 48 8D 4B 10, expected: 1, index: 0
+#pragma endregion
+
 #pragma region Memory
 constexpr uintptr_t Memory_Vault_Get = 0x1401959D0 - ImageBase; // 48 8D 05 ? ? ? ? C3, expected: 1275, index: 0
 constexpr uintptr_t Memory_Vault_Alloc = 0x140193AC0 - ImageBase; // 48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 30, expected: 1964, index: 5

--- a/include/RED4ext/Callback.hpp
+++ b/include/RED4ext/Callback.hpp
@@ -30,7 +30,8 @@ struct CallbackHandler
     template<typename T>
     using DestructFunc = void (*)(T* aTarget);
 
-    CallbackHandler(InvokeFunc<void> aInvoke, CopyFunc<void> aCopy, MoveFunc<void> aMove, DestructFunc<void> aDestruct) noexcept
+    CallbackHandler(InvokeFunc<void> aInvoke, CopyFunc<void> aCopy, MoveFunc<void> aMove,
+                    DestructFunc<void> aDestruct) noexcept
         : invoke(aInvoke)
         , copy(aCopy)
         , move(aMove)

--- a/include/RED4ext/Callback.hpp
+++ b/include/RED4ext/Callback.hpp
@@ -111,6 +111,30 @@ public:
         MoveTargetFrom(aOther.buffer);
     }
 
+    Callback& operator=(const Callback& aOther)
+    {
+        if (this != std::addressof(aOther))
+        {
+            DestroyTarget();
+            CopyHandlerFrom(aOther.handler);
+            CopyTargetFrom(aOther.buffer);
+        }
+
+        return *this;
+    }
+
+    Callback& operator=(Callback&& aOther) noexcept
+    {
+        if (this != std::addressof(aOther))
+        {
+            DestroyTarget();
+            MoveHandlerFrom(aOther.handler);
+            MoveTargetFrom(aOther.buffer);
+        }
+
+        return *this;
+    }
+
     ~Callback()
     {
         DestroyTarget();
@@ -237,6 +261,34 @@ public:
         InitializeBuffer(aOther.GetSize(), aOther.allocator);
         MoveHandlerFrom(aOther.handler);
         MoveTargetFrom(aOther.GetBuffer());
+    }
+
+    FlexCallback& operator=(const FlexCallback& aOther)
+    {
+        if (this != std::addressof(aOther))
+        {
+            DestroyTarget();
+            ResetBuffer();
+            InitializeBuffer(aOther.GetSize(), aOther.allocator);
+            CopyHandlerFrom(aOther.handler);
+            CopyTargetFrom(aOther.GetBuffer());
+        }
+
+        return *this;
+    }
+
+    FlexCallback& operator=(FlexCallback&& aOther) noexcept
+    {
+        if (this != std::addressof(aOther))
+        {
+            DestroyTarget();
+            ResetBuffer();
+            InitializeBuffer(aOther.GetSize(), aOther.allocator);
+            MoveHandlerFrom(aOther.handler);
+            MoveTargetFrom(aOther.GetBuffer());
+        }
+
+        return *this;
     }
 
     ~FlexCallback()

--- a/include/RED4ext/Callback.hpp
+++ b/include/RED4ext/Callback.hpp
@@ -178,7 +178,7 @@ private:
 
     R InvokeTarget(Args&&... aArgs) const
     {
-        return (handler->invoke)(buffer, std::forward<Args>(aArgs)...);
+        return handler->invoke(buffer, std::forward<Args>(aArgs)...);
     }
 
     void CopyTargetFrom(void* aTarget)
@@ -319,7 +319,7 @@ protected:
         using HandlerFactory = Detail::CallbackHandlerFactory<HandlerImpl, R, Args...>;
 
         handler = HandlerFactory::Get();
-        handler->copy(buffer, aSrc);
+        handler->copy(GetBuffer(), aSrc);
     }
 
     void CopyHandlerFrom(HandlerPtr aHandler) noexcept
@@ -407,7 +407,7 @@ protected:
 
     inline R InvokeTarget(Args&&... aArgs) const
     {
-        return (handler->invoke)(GetBuffer(), std::forward<Args>(aArgs)...);
+        return handler->invoke(GetBuffer(), std::forward<Args>(aArgs)...);
     }
 
     void CopyTargetFrom(void* aOther)

--- a/include/RED4ext/Callback.hpp
+++ b/include/RED4ext/Callback.hpp
@@ -7,14 +7,11 @@
 #include <RED4ext/Detail/Callback.hpp>
 #include <RED4ext/Memory/Allocators.hpp>
 
-namespace
+namespace RED4ext
 {
 constexpr size_t DefaultFixedCallbackBufferSize = 32;
 constexpr size_t DefaultFlexCallbackBufferSize = 24;
-}
 
-namespace RED4ext
-{
 template<typename R, typename... Args>
 struct CallbackHandler
 {
@@ -68,7 +65,7 @@ class Callback<R (*)(Args...), InlineSize>
 public:
     using HandlerPtr = CallbackHandler<R, Args...>*;
 
-    static_assert(InlineSize > sizeof(void*), "Buffer size can't be less than pointer size");
+    static_assert(InlineSize >= sizeof(void*), "Buffer size can't be less than pointer size");
 
     Callback(R (*aFunc)(Args...)) noexcept
     {
@@ -197,7 +194,7 @@ public:
     using HandlerPtr = CallbackHandler<R, Args...>*;
     using AllocatorType = Memory::DefaultAllocator;
 
-    static_assert(InlineSize > sizeof(void*), "Buffer size can't be less than pointer size");
+    static_assert(InlineSize >= sizeof(void*), "Buffer size can't be less than pointer size");
 
     FlexCallback(R (*aFunc)(Args...))
     {

--- a/include/RED4ext/Callback.hpp
+++ b/include/RED4ext/Callback.hpp
@@ -1,0 +1,381 @@
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+
+#include <RED4ext/Common.hpp>
+#include <RED4ext/Detail/Callback.hpp>
+#include <RED4ext/Memory/Allocators.hpp>
+
+namespace
+{
+constexpr size_t DefaultFixedCallbackBufferSize = 32;
+constexpr size_t DefaultFlexCallbackBufferSize = 24;
+}
+
+namespace RED4ext
+{
+template<typename R, typename... Args>
+struct CallbackHandler
+{
+    template<typename T>
+    using InvokeFunc = R (*)(T* aTarget, Args&&... aArgs);
+
+    template<typename T>
+    using CopyFunc = void (*)(T* aDst, T* aSrc);
+
+    template<typename T>
+    using MoveFunc = CopyFunc<T>;
+
+    template<typename T>
+    using DestructFunc = void (*)(T* aTarget);
+
+    CallbackHandler(InvokeFunc<void> aInvoke, CopyFunc<void> aCopy, MoveFunc<void> aMove, DestructFunc<void> aDestruct) noexcept
+        : invoke(aInvoke)
+        , copy(aCopy)
+        , move(aMove)
+        , destruct(aDestruct)
+    {
+    }
+
+    template<typename T>
+    CallbackHandler(InvokeFunc<T> aInvoke, CopyFunc<T> aCopy, MoveFunc<T> aMove, DestructFunc<T> aDestruct) noexcept
+        : invoke(reinterpret_cast<InvokeFunc<void>>(aInvoke))
+        , copy(reinterpret_cast<CopyFunc<void>>(aCopy))
+        , move(reinterpret_cast<MoveFunc<void>>(aMove))
+        , destruct(reinterpret_cast<DestructFunc<void>>(aDestruct))
+    {
+    }
+
+    InvokeFunc<void> invoke;     // 00
+    CopyFunc<void> copy;         // 08
+    MoveFunc<void> move;         // 10
+    DestructFunc<void> destruct; // 18
+};
+RED4EXT_ASSERT_SIZE(CallbackHandler<void>, 0x20);
+RED4EXT_ASSERT_OFFSET(CallbackHandler<void>, invoke, 0x00);
+RED4EXT_ASSERT_OFFSET(CallbackHandler<void>, copy, 0x08);
+RED4EXT_ASSERT_OFFSET(CallbackHandler<void>, move, 0x10);
+RED4EXT_ASSERT_OFFSET(CallbackHandler<void>, destruct, 0x18);
+
+template<typename T, size_t InlineSize = DefaultFixedCallbackBufferSize>
+class Callback;
+
+template<typename R, typename... Args, size_t InlineSize>
+class Callback<R (*)(Args...), InlineSize>
+{
+public:
+    using HandlerPtr = CallbackHandler<R, Args...>*;
+
+    static_assert(InlineSize > sizeof(void*), "Buffer size can't be less than pointer size");
+
+    Callback(R (*aFunc)(Args...)) noexcept
+    {
+        using TargetType = Detail::UnboundFunctionTarget<R, Args...>;
+
+        static_assert(sizeof(TargetType) <= InlineSize, "Function size is too big for this callback");
+
+        TargetType target{aFunc};
+        InitializeHandler(&target);
+    }
+
+    template<typename C>
+    Callback(C* aContext, R (C::*aFunc)(Args...)) noexcept
+    {
+        using TargetType = Detail::MemberFunctionTarget<C, R, Args...>;
+
+        static_assert(sizeof(TargetType) <= InlineSize, "Function size is too big for this callback");
+
+        TargetType target{aContext, aFunc};
+        InitializeHandler(&target);
+    }
+
+    template<typename L>
+    requires Detail::IsClosure<L, R, Args...>
+    Callback(L&& aClosure) noexcept
+    {
+        using TargetType = Detail::ClosureTarget<L, R, Args...>;
+
+        static_assert(sizeof(TargetType) <= InlineSize, "Closure size is too big for this callback");
+
+        InitializeHandler(reinterpret_cast<TargetType*>(&aClosure));
+    }
+
+    Callback(const Callback& aOther) noexcept
+    {
+        CopyHandlerFrom(aOther.handler);
+        CopyTargetFrom(aOther.buffer);
+    }
+
+    Callback(Callback&& aOther) noexcept
+    {
+        MoveHandlerFrom(aOther.handler);
+        MoveTargetFrom(aOther.buffer);
+    }
+
+    ~Callback()
+    {
+        DestroyTarget();
+        ResetHandler();
+    }
+
+    R operator()(Args&&... aArgs) const
+    {
+        return InvokeTarget(buffer, std::forward<Args>(aArgs)...);
+    }
+
+    uint8_t buffer[InlineSize];
+    HandlerPtr handler;
+
+private:
+    Callback() = default;
+
+    template<class TargetType>
+    void InitializeHandler(TargetType* aSrc) noexcept
+    {
+        using HandlerImpl = Detail::CallbackHandlerImpl<TargetType>;
+        using HandlerFactory = Detail::CallbackHandlerFactory<HandlerImpl, R, Args...>;
+
+        handler = HandlerFactory::Get();
+        handler->copy(buffer, aSrc);
+    }
+
+    void CopyHandlerFrom(HandlerPtr aHandler) noexcept
+    {
+        handler = aHandler;
+    }
+
+    void MoveHandlerFrom(HandlerPtr& aHandler) noexcept
+    {
+        handler = aHandler;
+        aHandler = nullptr;
+    }
+
+    void ResetHandler() noexcept
+    {
+        handler = nullptr;
+    }
+
+    R InvokeTarget(Args&&... aArgs) const
+    {
+        return (handler->invoke)(buffer, std::forward<Args>(aArgs)...);
+    }
+
+    void CopyTargetFrom(void* aTarget)
+    {
+        if (handler)
+        {
+            handler->copy(buffer, aTarget);
+        }
+    }
+
+    void MoveTargetFrom(void* aTarget)
+    {
+        if (handler)
+        {
+            handler->move(buffer, aTarget);
+        }
+    }
+
+    void DestroyTarget()
+    {
+        if (handler)
+        {
+            handler->destruct(buffer);
+        }
+    }
+};
+RED4EXT_ASSERT_SIZE(Callback<void (*)()>, DefaultFixedCallbackBufferSize + 0x8);
+RED4EXT_ASSERT_OFFSET(Callback<void (*)()>, handler, DefaultFixedCallbackBufferSize);
+
+template<typename T, size_t InlineSize = DefaultFlexCallbackBufferSize>
+class FlexCallback;
+
+template<typename R, typename... Args, size_t InlineSize>
+class FlexCallback<R (*)(Args...), InlineSize>
+{
+public:
+    using HandlerPtr = CallbackHandler<R, Args...>*;
+    using AllocatorType = Memory::DefaultAllocator;
+
+    static_assert(InlineSize > sizeof(void*), "Buffer size can't be less than pointer size");
+
+    FlexCallback(R (*aFunc)(Args...))
+    {
+        using TargetType = Detail::UnboundFunctionTarget<R, Args...>;
+
+        TargetType target{aFunc};
+        InitializeBuffer(sizeof(TargetType));
+        InitializeHandler(&target);
+    }
+
+    template<typename C>
+    FlexCallback(C* aContext, R (C::*aFunc)(Args...))
+    {
+        using TargetType = Detail::MemberFunctionTarget<C, R, Args...>;
+
+        TargetType target{aContext, aFunc};
+        InitializeBuffer(sizeof(TargetType));
+        InitializeHandler(&target);
+    }
+
+    template<typename L>
+    requires Detail::IsClosure<L, R, Args...>
+    FlexCallback(L&& aClosure)
+    {
+        using TargetType = Detail::ClosureTarget<L, R, Args...>;
+
+        InitializeBuffer(sizeof(TargetType));
+        InitializeHandler(reinterpret_cast<TargetType*>(&aClosure));
+    }
+
+    FlexCallback(const FlexCallback& aOther)
+    {
+        InitializeBuffer(aOther.GetSize());
+        CopyHandlerFrom(aOther.handler);
+        CopyTargetFrom(aOther.GetBuffer());
+    }
+
+    FlexCallback(FlexCallback&& aOther) noexcept
+    {
+        InitializeBuffer(aOther.GetSize());
+        MoveHandlerFrom(aOther.handler);
+        MoveTargetFrom(aOther.GetBuffer());
+    }
+
+    ~FlexCallback()
+    {
+        DestroyTarget();
+        ResetBuffer();
+        ResetHandler();
+    }
+
+    R operator()(Args&&... aArgs) const
+    {
+        return InvokeTarget(std::forward<Args>(aArgs)...);
+    }
+
+    uint8_t buffer[InlineSize];
+    HandlerPtr handler;
+    Memory::IAllocator* allocator;
+    uint32_t extendedSize;
+
+protected:
+    static constexpr uint32_t ExtendedFlag = 0x80000000;
+    static constexpr uint32_t SizeMask = ~ExtendedFlag;
+
+    template<class TargetType>
+    void InitializeHandler(TargetType* aSrc) noexcept
+    {
+        using HandlerImpl = Detail::CallbackHandlerImpl<TargetType>;
+        using HandlerFactory = Detail::CallbackHandlerFactory<HandlerImpl, R, Args...>;
+
+        handler = HandlerFactory::Get();
+        handler->copy(buffer, aSrc);
+    }
+
+    void CopyHandlerFrom(HandlerPtr aHandler) noexcept
+    {
+        handler = aHandler;
+    }
+
+    void MoveHandlerFrom(HandlerPtr& aHandler) noexcept
+    {
+        handler = aHandler;
+        aHandler = nullptr;
+    }
+
+    void ResetHandler() noexcept
+    {
+        handler = nullptr;
+    }
+
+    void InitializeBuffer(uint32_t aSize)
+    {
+        if (aSize > InlineSize)
+        {
+            allocator = AllocatorType::Get();
+
+            auto bufferPtr = reinterpret_cast<void**>(buffer);
+            *bufferPtr = allocator->Alloc(aSize).memory;
+
+            extendedSize = aSize;
+            extendedSize |= ExtendedFlag;
+        }
+        else
+        {
+            extendedSize = 0;
+        }
+    }
+
+    [[nodiscard]] inline bool IsInlineMode() const noexcept
+    {
+        return extendedSize == 0;
+    }
+
+    [[nodiscard]] inline bool IsExtendedMode() const noexcept
+    {
+        return extendedSize != 0;
+    }
+
+    [[nodiscard]] inline uint32_t GetSize() const noexcept
+    {
+        if (IsExtendedMode())
+        {
+            return extendedSize & SizeMask;
+        }
+
+        return InlineSize;
+    }
+
+    [[nodiscard]] void* GetBuffer() noexcept
+    {
+        if (IsExtendedMode())
+        {
+            return *reinterpret_cast<void**>(buffer);
+        }
+
+        return buffer;
+    }
+
+    void ResetBuffer()
+    {
+        if (IsExtendedMode())
+        {
+            AllocatorType::Get()->Free(GetBuffer());
+            extendedSize = 0;
+        }
+    }
+
+    inline R InvokeTarget(Args&&... aArgs) const
+    {
+        return (handler->invoke)(GetBuffer(), std::forward<Args>(aArgs)...);
+    }
+
+    void CopyTargetFrom(void* aOther)
+    {
+        if (handler)
+        {
+            handler->copy(GetBuffer(), aOther);
+        }
+    }
+
+    void MoveTargetFrom(void* aOther)
+    {
+        if (handler)
+        {
+            handler->move(GetBuffer(), aOther);
+        }
+    }
+
+    void DestroyTarget()
+    {
+        if (handler)
+        {
+            handler->destruct(GetBuffer());
+        }
+    }
+};
+RED4EXT_ASSERT_SIZE(FlexCallback<void (*)()>, DefaultFlexCallbackBufferSize + 0x18);
+RED4EXT_ASSERT_OFFSET(FlexCallback<void (*)()>, extendedSize, DefaultFlexCallbackBufferSize + 0x10);
+} // namespace RED4ext

--- a/include/RED4ext/Detail/Callback.hpp
+++ b/include/RED4ext/Detail/Callback.hpp
@@ -46,7 +46,7 @@ struct CallbackHandlerImpl<UnboundFunctionTarget<R, Args...>>
 
     static R Invoke(TargetType* aTarget, Args&&... aArgs)
     {
-        (aTarget->func)(std::forward<Args>(aArgs)...);
+        std::invoke(aTarget->func, std::forward<Args>(aArgs)...);
     }
 
     static void Copy(TargetType* aDst, TargetType* aSrc)
@@ -73,7 +73,7 @@ struct CallbackHandlerImpl<MemberFunctionTarget<C, R, Args...>>
 
     static R Invoke(TargetType* aTarget, Args&&... aArgs)
     {
-        ((aTarget->context)->*(aTarget->func))(std::forward<Args>(aArgs)...);
+        std::invoke(aTarget->func, aTarget->context, std::forward<Args>(aArgs)...);
     }
 
     static void Copy(TargetType* aDst, TargetType* aSrc)

--- a/include/RED4ext/Detail/Callback.hpp
+++ b/include/RED4ext/Detail/Callback.hpp
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <type_traits>
+
+#include <RED4ext/Detail/Function.hpp>
+
+namespace RED4ext
+{
+template<typename R, typename... Args>
+struct CallbackHandler;
+
+namespace Detail
+{
+template<typename R, typename... Args>
+struct UnboundFunctionTarget
+{
+    using TargetFunc = UnboundFunctionPtr<R, Args...>;
+
+    TargetFunc func;
+};
+
+template<typename C, typename R, typename... Args>
+struct MemberFunctionTarget
+{
+    using TargetFunc = MemberFunctionPtr<C, R, Args...>;
+    using ContextPtr = C*;
+
+    ContextPtr context;
+    TargetFunc func;
+};
+
+template<typename L, typename R, typename... Args>
+requires IsClosure<L, R, Args...>
+struct ClosureTarget : L
+{
+    using ClosureType = L;
+};
+
+template<typename T>
+struct CallbackHandlerImpl;
+
+template<typename R, typename... Args>
+struct CallbackHandlerImpl<UnboundFunctionTarget<R, Args...>>
+{
+    using TargetType = UnboundFunctionTarget<R, Args...>;
+
+    static R Invoke(TargetType* aTarget, Args&&... aArgs)
+    {
+        (aTarget->func)(std::forward<Args>(aArgs)...);
+    }
+
+    static void Copy(TargetType* aDst, TargetType* aSrc)
+    {
+        aDst->func = aSrc->func;
+    }
+
+    static void Move(TargetType* aDst, TargetType* aSrc)
+    {
+        aDst->func = aSrc->func;
+        aSrc->func = nullptr;
+    }
+
+    static void Destruct(TargetType* aTarget)
+    {
+        aTarget->func = nullptr;
+    }
+};
+
+template<typename C, typename R, typename... Args>
+struct CallbackHandlerImpl<MemberFunctionTarget<C, R, Args...>>
+{
+    using TargetType = MemberFunctionTarget<C, R, Args...>;
+
+    static R Invoke(TargetType* aTarget, Args&&... aArgs)
+    {
+        ((aTarget->context)->*(aTarget->func))(std::forward<Args>(aArgs)...);
+    }
+
+    static void Copy(TargetType* aDst, TargetType* aSrc)
+    {
+        aDst->context = aSrc->context;
+        aDst->func = aSrc->func;
+    }
+
+    static void Move(TargetType* aDst, TargetType* aSrc)
+    {
+        aDst->context = aSrc->context;
+        aDst->func = aSrc->func;
+        aSrc->context = nullptr;
+        aSrc->func = nullptr;
+    }
+
+    static void Destruct(TargetType* aTarget)
+    {
+        aTarget->context = nullptr;
+        aTarget->func = nullptr;
+    }
+};
+
+template<typename L, typename R, typename... Args>
+requires IsClosure<L, R, Args...>
+struct CallbackHandlerImpl<ClosureTarget<L, R, Args...>>
+{
+    using TargetType = typename ClosureTarget<L, R, Args...>::ClosureType;
+
+    static R Invoke(TargetType* aTarget, Args&&... aArgs)
+    {
+        (*aTarget)(std::forward<Args>(aArgs)...);
+    }
+
+    static void Copy(TargetType* aDst, TargetType* aSrc)
+    {
+        new (aDst) TargetType(*aSrc);
+    }
+
+    static void Move(TargetType* aDst, TargetType* aSrc)
+    {
+        new (aDst) TargetType(std::move(*aSrc));
+        aSrc->~TargetType();
+    }
+
+    static void Destruct(TargetType* aTarget)
+    {
+        aTarget->~TargetType();
+    }
+};
+
+template<typename Impl, typename R, typename... Args>
+struct CallbackHandlerFactory
+{
+    using HandlerType = CallbackHandler<R, Args...>;
+
+    static HandlerType* Get() noexcept
+    {
+        static HandlerType s_handler{&Impl::Invoke, &Impl::Copy, &Impl::Move, &Impl::Destruct};
+        return &s_handler;
+    }
+};
+} // namespace Detail
+} // namespace RED4ext

--- a/include/RED4ext/Detail/Function.hpp
+++ b/include/RED4ext/Detail/Function.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <concepts>
+#include <type_traits>
+
+namespace RED4ext::Detail
+{
+template<typename R, typename... Args>
+using UnboundFunctionPtr = R (*)(Args...);
+
+template<typename C, typename R, typename... Args>
+using MemberFunctionPtr = R (C::*)(Args...);
+
+// clang-format off
+template<typename T, typename R, typename... Args>
+concept IsClosure = std::is_class_v<T> && requires(T t, Args... args)
+{
+    { t(std::forward<Args>(args)...) } -> std::convertible_to<R>;
+};
+// clang-format on
+} // namespace RED4ext::Detail

--- a/include/RED4ext/Detail/Memory.hpp
+++ b/include/RED4ext/Detail/Memory.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <type_traits>
 
 namespace RED4ext

--- a/include/RED4ext/JobQueue-inl.hpp
+++ b/include/RED4ext/JobQueue-inl.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/JobQueue.hpp>
+#endif
+
+#include <RED4ext/Addresses.hpp>
+#include <RED4ext/Hashing/FNV1a.hpp>
+#include <RED4ext/Relocation.hpp>
+
+void RED4ext::JobInternals::SetLocalThreadParam(uint8_t aParam)
+{
+    using func_t = void (*)(uint8_t);
+    RelocFunc<func_t> func(Addresses::JobInternals_SetLocalThreadParam);
+
+    func(aParam);
+}
+
+RED4ext::JobFamily::JobFamily(const char* aName) noexcept
+    : name(aName)
+    , unk08("src")
+    , unk10("func")
+    , unk18(1)
+    , unk1C(0)
+    , unk20(0)
+    , unk24(0)
+    , hash(FNV1a32(name))
+    , unk2C(0)
+    , unk30(0)
+    , unk34(1)
+    , unk38(0)
+    , unk3C(0)
+{
+}
+
+RED4ext::JobParamSet::JobParamSet() noexcept
+    : unk00(0)
+    , unk01(0)
+    , unk02(255)
+{
+}
+
+RED4ext::JobHandle::JobHandle(JobParamSet aParams, uintptr_t aUnk)
+    : unk00(nullptr)
+{
+    using func_t = void (*)(JobHandle*, JobParamSet&, uintptr_t);
+    RelocFunc<func_t> func(Addresses::JobHandle_ctor);
+
+    func(this, aParams, aUnk);
+}
+
+RED4ext::JobHandle::~JobHandle()
+{
+    using func_t = void (*)(JobHandle*);
+    RelocFunc<func_t> func(Addresses::JobHandle_dtor);
+
+    func(this);
+}
+
+void RED4ext::JobHandle::Join(const JobHandle& aOther)
+{
+    using func_t = void (*)(JobHandle*, const JobHandle&);
+    RelocFunc<func_t> func(Addresses::JobHandle_Join);
+
+    func(this, aOther);
+}
+
+RED4ext::JobQueue::JobQueue(const JobGroup& aGroup)
+{
+    using func_t = JobQueue* (*)(JobQueue*, const JobGroup&);
+    RelocFunc<func_t> func(Addresses::JobQueue_ctor_FromGroup);
+
+    func(this, aGroup);
+}
+
+RED4ext::JobQueue::JobQueue(JobParamSet aParams, uintptr_t aUnk)
+{
+    using func_t = JobQueue* (*)(JobQueue*, JobParamSet&, uint64_t);
+    RelocFunc<func_t> func(Addresses::JobQueue_ctor_FromParams);
+
+    func(this, aParams, aUnk);
+}
+
+RED4ext::JobQueue::~JobQueue()
+{
+    using func_t = void (*)(JobQueue*);
+    RelocFunc<func_t> func(Addresses::JobQueue_dtor);
+
+    func(this);
+}
+
+void RED4ext::JobQueue::Wait(JobHandle& aJob)
+{
+    unk10.Join(aJob);
+}
+
+[[nodiscard]] RED4ext::JobHandle RED4ext::JobQueue::Capture()
+{
+    using func_t = JobHandle* (*)(JobQueue*, JobHandle*);
+    RelocFunc<func_t> func(Addresses::JobQueue_Capture);
+
+    JobHandle handle{};
+    func(this, &handle);
+
+    return std::move(handle);
+}
+
+void RED4ext::JobQueue::DispatchJob(const JobInstance& aJob)
+{
+    using func_t = void (*)(const JobInstance&, JobHandle&, JobHandle&);
+    RelocFunc<func_t> func(Addresses::JobInternals_DispatchJob);
+
+    func(aJob, unk10, unk18);
+}
+
+void RED4ext::JobQueue::SyncWait()
+{
+    using func_t = void (*)(JobQueue*);
+    RelocFunc<func_t> func(Addresses::JobQueue_SyncWait);
+
+    func(this);
+}

--- a/include/RED4ext/JobQueue.hpp
+++ b/include/RED4ext/JobQueue.hpp
@@ -48,8 +48,8 @@ struct JobParamSet
     JobParamSet& operator=(JobParamSet&&) = default;
 
     uint8_t unk00; // 00
-	uint8_t unk01; // 01
-	uint8_t unk02; // 02
+    uint8_t unk01; // 01
+    uint8_t unk02; // 02
 };
 RED4EXT_ASSERT_SIZE(JobParamSet, 0x3);
 
@@ -133,7 +133,7 @@ struct JobInstance
 
     HandleFunc<void> handler; // 00 - Called by job dispatcher to execute the job
     TargetPtr<void> target;   // 08 - Job data that is passed to the handler
-	JobFamily* family;        // 10
+    JobFamily* family;        // 10
     uint64_t unk18;           // 18
 };
 RED4EXT_ASSERT_SIZE(JobInstance, 0x20);
@@ -258,9 +258,9 @@ public:
     JobHandle unk18;    // 18
     uintptr_t unk20;    // 20
     JobParamSet params; // 28
-	uint32_t unk2C;     // 2C
-	bool captured;      // 30
-	uint8_t unk31;      // 31
+    uint32_t unk2C;     // 2C
+    bool captured;      // 30
+    uint8_t unk31;      // 31
 
 private:
     void DispatchJob(const JobInstance& aJob);

--- a/include/RED4ext/JobQueue.hpp
+++ b/include/RED4ext/JobQueue.hpp
@@ -1,0 +1,278 @@
+#pragma once
+
+#include <RED4ext/Common.hpp>
+#include <RED4ext/Detail/Function.hpp>
+#include <RED4ext/Memory/Allocators.hpp>
+#include <RED4ext/Memory/Utils.hpp>
+
+namespace RED4ext
+{
+namespace JobInternals
+{
+void SetLocalThreadParam(uint8_t aParam);
+} // namespace JobInternals
+
+/**
+ * @brief Represents a class of jobs. In other words, for each T in Dispatch<T>(T aJob)
+ * there is one instance of the family. The actual purpose is unknown.
+ */
+struct JobFamily
+{
+    explicit JobFamily(const char* aName = "") noexcept;
+
+    const char* name;  // 00
+    const char* unk08; // 08
+    const char* unk10; // 10
+    uint32_t unk18;    // 18
+    uint32_t unk1C;    // 1C
+    uint32_t unk20;    // 20
+    uint32_t unk24;    // 24
+    uint32_t hash;     // 28
+    uint32_t unk2C;    // 2C
+    uint32_t unk30;    // 30
+    uint32_t unk34;    // 34
+    uint16_t unk38;    // 38
+    uint32_t unk3C;    // 3C
+};
+RED4EXT_ASSERT_SIZE(JobFamily, 0x40);
+RED4EXT_ASSERT_OFFSET(JobFamily, name, 0x00);
+RED4EXT_ASSERT_OFFSET(JobFamily, hash, 0x28);
+RED4EXT_ASSERT_OFFSET(JobFamily, unk3C, 0x3C);
+
+struct JobParamSet
+{
+    JobParamSet() noexcept;
+    JobParamSet(const JobParamSet&) = default;
+    JobParamSet(JobParamSet&&) = default;
+    JobParamSet& operator=(const JobParamSet&) = default;
+    JobParamSet& operator=(JobParamSet&&) = default;
+
+    uint8_t unk00; // 00
+	uint8_t unk01; // 01
+	uint8_t unk02; // 02
+};
+RED4EXT_ASSERT_SIZE(JobParamSet, 0x3);
+
+/**
+ * @brief A handle associated with a job queue or job group.
+ * It's used to track job completion and sync job execution.
+ */
+struct JobHandle
+{
+    JobHandle() = default;
+    JobHandle(const JobHandle&) = default;
+    JobHandle(JobHandle&&) = default;
+    JobHandle(JobParamSet aParams, uint64_t a2 = 0);
+    ~JobHandle();
+
+    /**
+     * @brief
+     *
+     * @param aOther
+     */
+    void Join(const JobHandle& aOther);
+
+    void* unk00; // 00
+};
+RED4EXT_ASSERT_SIZE(JobHandle, 0x8);
+
+/**
+ * @brief A group that joins several job queues together.
+ * A group is considered completed when all queues in the group have completed.
+ * Job queues from the same group are executed simultaneously.
+ * To be added to a group, the job queue must be constructed using a group instance,
+ * which can be obtained as a first argument to the currently executing job function.
+ */
+struct JobGroup
+{
+    JobGroup() = delete;
+    JobGroup(const JobGroup&) = delete;
+    JobGroup(JobGroup&&) = delete;
+    JobGroup& operator=(const JobGroup&) = delete;
+    JobGroup& operator=(JobGroup&&) = delete;
+
+    uint64_t unk00;     // 00
+    uint64_t unk08;     // 08
+    uint64_t unk10;     // 10
+    uint64_t unk18;     // 18
+    uint64_t unk20;     // 20
+    uint64_t unk28;     // 28
+    JobParamSet params; // 30
+};
+RED4EXT_ASSERT_SIZE(JobGroup, 0x38);
+RED4EXT_ASSERT_OFFSET(JobGroup, params, 0x30);
+
+/**
+ * @brief A payload for the job dispatcher.
+ * Contains job data and a handler function to execute.
+ */
+struct JobInstance
+{
+    template<typename T>
+    using TargetPtr = T*;
+
+    template<typename T>
+    using HandleFunc = void (*)(TargetPtr<T> aTarget, const JobGroup& aGroup);
+
+    JobInstance(HandleFunc<void> aHandler, TargetPtr<void> aTarget, JobFamily* aFamily) noexcept
+        : handler(aHandler)
+        , target(aTarget)
+        , family(aFamily)
+        , unk18(0)
+    {
+    }
+
+    template<typename T>
+    JobInstance(HandleFunc<T> aHandler, TargetPtr<T> aTarget, JobFamily* aFamily) noexcept
+        : handler(reinterpret_cast<HandleFunc<void>>(aHandler))
+        , target(reinterpret_cast<TargetPtr<void>>(aTarget))
+        , family(aFamily)
+        , unk18(0)
+    {
+    }
+
+    HandleFunc<void> handler; // 00 - Called by job dispatcher to execute the job
+    TargetPtr<void> target;   // 08 - Job data that is passed to the handler
+	JobFamily* family;        // 10
+    uint64_t unk18;           // 18
+};
+RED4EXT_ASSERT_SIZE(JobInstance, 0x20);
+RED4EXT_ASSERT_OFFSET(JobInstance, handler, 0x00);
+RED4EXT_ASSERT_OFFSET(JobInstance, target, 0x08);
+RED4EXT_ASSERT_OFFSET(JobInstance, family, 0x10);
+
+/**
+ * @brief An implementation of closure based jobs.
+ *
+ * @tparam L The closure type.
+ */
+template<typename L>
+requires Detail::IsClosure<L, void, const JobGroup&> || Detail::IsClosure<L, void>
+struct JobClosure : JobInstance
+{
+    using AllocatorType = Memory::Jobs2DataAllocator;
+    using ClosureType = L;
+    using ClosurePtr = L*;
+
+    JobClosure(ClosureType&& aClosure)
+        : JobInstance(&HandleTarget, CreateTarget(std::move(aClosure)), &GetFamily())
+    {
+    }
+
+    static ClosurePtr CreateTarget(ClosureType&& aClosure)
+    {
+        // In this case the target is the closure itself.
+        // We move the closure to our storage to extend its lifetime until the job is executed.
+        return Memory::New<AllocatorType, ClosureType>(std::move(aClosure));
+    }
+
+    static void HandleTarget(ClosurePtr aTarget, const JobGroup& aGroup)
+    {
+        JobInternals::SetLocalThreadParam(aGroup.params.unk02);
+
+        if constexpr (Detail::IsClosure<ClosureType, void, const JobGroup&>)
+        {
+            (*aTarget)(aGroup);
+        }
+        else
+        {
+            (*aTarget)();
+        }
+
+        JobInternals::SetLocalThreadParam(255);
+        Memory::Delete<AllocatorType>(aTarget);
+    }
+
+    inline static JobFamily& GetFamily()
+    {
+        static JobFamily s_family;
+        return s_family;
+    }
+};
+
+/**
+ * @brief A queue used to dispatch new backgroud jobs.
+ * Job processing starts as soon as possible. If the job dispatcher is free,
+ * the job will be executed immediately after it's added to the queue.
+ * All jobs in the same queue are executed sequentially in the order added.
+ * A queue is considered completed when all jobs in the queue have completed.
+ * Any number of queues can exist and execute at the same time.
+ */
+class JobQueue
+{
+public:
+    /**
+     * @brief Starts a new queue and adds it to an existing group.
+     *
+     * @param aGroup The group instane to add the queue to.
+     */
+    explicit JobQueue(const JobGroup& aGroup);
+
+    /**
+     * @brief Starts a new queue with a new group.
+     *
+     * @param aParams An unknown param that usually has a default value.
+     * @param aUnk An unknown param that's usually null.
+     */
+    explicit JobQueue(JobParamSet aParams = {}, uintptr_t aUnk = 0);
+
+    JobQueue(const JobQueue&) = delete;
+    JobQueue(JobQueue&&) = delete;
+    JobQueue& operator=(const JobQueue&) = delete;
+    JobQueue& operator=(JobQueue&&) = delete;
+
+    ~JobQueue();
+
+    /**
+     * @brief Adds a closure based job to the queue.
+     *
+     * @tparam L The closure type.
+     * @param aClosure The closure instance.
+     */
+    template<typename L>
+    requires Detail::IsClosure<L, void, JobGroup&> || Detail::IsClosure<L, void>
+    void Dispatch(L&& aClosure)
+    {
+        DispatchJob(JobClosure(std::move(aClosure)));
+        SyncWait();
+    }
+
+    /**
+     * @brief Adds a waiting point to the queue.
+     *
+     * @param aJob The job to wait before continuing the queue.
+     */
+    void Wait(JobHandle& aJob);
+
+    /**
+     * @brief Finalizes the queue and returns a job handle associated with this queue.
+     * This should be the last action after which no jobs should be added to the queue.
+     *
+     * @return A job handle that can be passed to a Wait() call on another queue.
+     */
+    [[nodiscard]] JobHandle Capture();
+
+    const char* unk00;  // 00
+    uintptr_t unk08;    // 08
+    JobHandle unk10;    // 10
+    JobHandle unk18;    // 18
+    uintptr_t unk20;    // 20
+    JobParamSet params; // 28
+	uint32_t unk2C;     // 2C
+	bool captured;      // 30
+	uint8_t unk31;      // 31
+
+private:
+    void DispatchJob(const JobInstance& aJob);
+    void SyncWait();
+};
+RED4EXT_ASSERT_SIZE(JobQueue, 0x38);
+RED4EXT_ASSERT_OFFSET(JobQueue, unk10, 0x10);
+RED4EXT_ASSERT_OFFSET(JobQueue, unk18, 0x18);
+RED4EXT_ASSERT_OFFSET(JobQueue, params, 0x28);
+RED4EXT_ASSERT_OFFSET(JobQueue, unk2C, 0x2C);
+} // namespace RED4ext
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/JobQueue-inl.hpp>
+#endif

--- a/include/RED4ext/JobQueue.hpp
+++ b/include/RED4ext/JobQueue.hpp
@@ -62,13 +62,14 @@ struct JobHandle
     JobHandle() = default;
     JobHandle(const JobHandle&) = default;
     JobHandle(JobHandle&&) = default;
-    JobHandle(JobParamSet aParams, uint64_t a2 = 0);
+    JobHandle(JobParamSet aParams, uintptr_t aUnk = 0);
     ~JobHandle();
 
     /**
-     * @brief
+     * @brief Joins another job handle to this one.
+     * The joint handle represents the completion of all joined handles.
      *
-     * @param aOther
+     * @param aOther The job handle to join.
      */
     void Join(const JobHandle& aOther);
 

--- a/include/RED4ext/RTTISystem.hpp
+++ b/include/RED4ext/RTTISystem.hpp
@@ -3,6 +3,7 @@
 #include <Windows.h>
 #include <cstdint>
 
+#include <RED4ext/Callback.hpp>
 #include <RED4ext/CName.hpp>
 #include <RED4ext/Common.hpp>
 #include <RED4ext/DynArray.hpp>
@@ -39,8 +40,8 @@ struct IRTTISystem
     virtual void RegisterFunction(CGlobalFunction* aFunc) = 0;                                // 98
     virtual void UnregisterFunction(CGlobalFunction* aFunc) = 0;                              // A0
     virtual void sub_A8() = 0;                                                                // A8
-    virtual void sub_B0() = 0;                                                                // B0
-    virtual void sub_B8() = 0;                                                                // B8
+    virtual void AddRegisterCallback(Callback<void (*)()>) = 0;                               // B0
+    virtual void AddPostRegisterCallback(Callback<void (*)()>) = 0;                           // B8
     virtual void sub_C0() = 0;                                                                // C0
     virtual void sub_C8() = 0;                                                                // C8
     virtual void CreateScriptedClass(CName aName, CClass::Flags aFlags, CClass* aParent) = 0; // D0

--- a/include/RED4ext/ResourceLoader.hpp
+++ b/include/RED4ext/ResourceLoader.hpp
@@ -130,7 +130,7 @@ struct ResourceLoader
         SharedPtr<ResourceToken<T>> token;
         func(this, &token, aPath);
 
-        return std::move(token);
+        return token;
     }
 
     template<typename T = CResource>
@@ -142,7 +142,7 @@ struct ResourceLoader
         SharedPtr<ResourceToken<T>> token;
         func(this, &token, aPath);
 
-        return std::move(token);
+        return token;
     }
 
     HashMap<ResourcePath, WeakPtr<ResourceToken<>>> tokens; // 00

--- a/include/RED4ext/ResourceLoader.hpp
+++ b/include/RED4ext/ResourceLoader.hpp
@@ -2,9 +2,12 @@
 
 #include <type_traits>
 
+#include <RED4ext/Addresses.hpp>
+#include <RED4ext/Callback.hpp>
 #include <RED4ext/Common.hpp>
 #include <RED4ext/DynArray.hpp>
 #include <RED4ext/HashMap.hpp>
+#include <RED4ext/JobQueue.hpp>
 #include <RED4ext/Memory/Allocators.hpp>
 #include <RED4ext/Memory/SharedPtr.hpp>
 #include <RED4ext/Relocation.hpp>
@@ -17,6 +20,7 @@ template<typename T = CResource>
 struct ResourceToken
 {
     using AllocatorType = Memory::EngineAllocator;
+    using LoadedCallback = FlexCallback<void (*)(RED4ext::Handle<T>&)>;
 
     ResourceToken() = delete;
     ResourceToken(const ResourceToken&) = delete;
@@ -28,6 +32,20 @@ struct ResourceToken
         RelocFunc<Destruct_t> func(Addresses::ResourceToken_dtor);
 
         func(this);
+    }
+
+    /**
+     * @brief Register callback for the resource load event.
+     *
+     * @param aCallback The callback.
+     */
+    void OnLoaded(LoadedCallback aCallback)
+    {
+        using OnLoaded_t = JobHandle* (*)(ResourceToken*, JobHandle*, LoadedCallback*);
+        RED4ext::RelocFunc<OnLoaded_t> func(Addresses::ResourceToken_OnLoaded);
+
+        JobHandle handle{};
+        func(this, &handle, &aCallback);
     }
 
     /**
@@ -48,22 +66,22 @@ struct ResourceToken
      *
      * @return The loaded resource.
      */
-    Handle<T>& Get() const noexcept
+    [[nodiscard]] Handle<T>& Get() const noexcept
     {
         return resource;
     }
 
-    inline bool IsFinished() const noexcept
+    [[nodiscard]] inline bool IsFinished() const noexcept
     {
         return IsLoaded() || IsFailed();
     }
 
-    inline bool IsLoaded() const noexcept
+    [[nodiscard]] inline bool IsLoaded() const noexcept
     {
         return finished && !error;
     }
 
-    inline bool IsFailed() const noexcept
+    [[nodiscard]] inline bool IsFailed() const noexcept
     {
         return error;
     }
@@ -82,11 +100,11 @@ struct ResourceToken
 
     WeakPtr<ResourceToken<T>> self;                    // 00
     DynArray<SharedPtr<ResourceToken<>>> dependencies; // 10
-    uint8_t unk20;                                     // 20
+    SharedMutex lock;                                  // 20
     Handle<T> resource;                                // 28
     SharedPtr<Unk38> unk38;                            // 38
     ResourcePath path;                                 // 48
-    uintptr_t unk50;                                   // 50
+    JobHandle job;                                     // 50
     volatile int32_t finished;                         // 58
     uint8_t error;                                     // 5C
     uint8_t unk5D;                                     // 5D
@@ -112,7 +130,7 @@ struct ResourceLoader
         SharedPtr<ResourceToken<T>> token;
         func(this, &token, aPath);
 
-        return token;
+        return std::move(token);
     }
 
     template<typename T = CResource>
@@ -124,7 +142,7 @@ struct ResourceLoader
         SharedPtr<ResourceToken<T>> token;
         func(this, &token, aPath);
 
-        return token;
+        return std::move(token);
     }
 
     HashMap<ResourcePath, WeakPtr<ResourceToken<>>> tokens; // 00

--- a/scripts/find_patterns.py
+++ b/scripts/find_patterns.py
@@ -100,6 +100,7 @@ try:
         file.write('#include <cstdint>\n')
         file.write('\n')
         file.write(f'// Addresses for Cyberpunk 2077, version {version.decode()}.\n')
+        file.write(f'// clang-format off\n')
         file.write('namespace RED4ext::Addresses\n')
         file.write('{\n')
         file.write(f'constexpr uintptr_t ImageBase = 0x{ida_nalt.get_imagebase():X};\n')
@@ -156,6 +157,7 @@ try:
                 file.write('\n')
 
         file.write('} // namespace RED4ext::Addresses\n')
+        file.write(f'// clang-format on\n')
 
         print('Done!')
         ida_kernwin.beep()

--- a/scripts/find_patterns.py
+++ b/scripts/find_patterns.py
@@ -100,7 +100,7 @@ try:
         file.write('#include <cstdint>\n')
         file.write('\n')
         file.write(f'// Addresses for Cyberpunk 2077, version {version.decode()}.\n')
-        file.write(f'// clang-format off\n')
+        file.write('// clang-format off\n')
         file.write('namespace RED4ext::Addresses\n')
         file.write('{\n')
         file.write(f'constexpr uintptr_t ImageBase = 0x{ida_nalt.get_imagebase():X};\n')
@@ -157,7 +157,7 @@ try:
                 file.write('\n')
 
         file.write('} // namespace RED4ext::Addresses\n')
-        file.write(f'// clang-format on\n')
+        file.write('// clang-format on\n')
 
         print('Done!')
         ida_kernwin.beep()

--- a/scripts/patterns.py
+++ b/scripts/patterns.py
@@ -141,6 +141,25 @@ def get_groups() -> List[Group]:
             Item(name='GetValueHolder', pattern='40 53 48 83 EC 20 48 83 79 38 00 48 8B D9 75', expected=2, index=1)
         ]),
 
+        Group(name='JobHandle', functions=[
+            Item(name='ctor', pattern='40 53 48 83 EC 20 0F B7 02 48 8B D9 48 8B 0D ? ? ? ? 4D 8B C8 66 89 44 24 30 4C 8D 44 24 30'),
+            Item(name='dtor', pattern='40 53 48 83 EC 20 48 8B 11 48 8B D9 48 85 D2 74 13 48 8B 0D ? ? ? ? E8 ? ? ? ?'),
+            Item(name='Join', pattern='48 89 5C 24 08 57 48 83 EC 40 48 8B FA 48 8B D9 48 8B 12 48 8B 0D ? ? ? ? E8 ? ? ? ?')
+        ]),
+
+        Group(name='JobInternals', functions=[
+            Item(name='SetLocalThreadParam', pattern='8B 15 ? ? ? ? 65 48 8B 04 25 58 00 00 00 41 B8 ? ? ? ? 48 8B 04 D0 41 88 0C 00 C3', expected=4, index=2),
+            Item(name='DispatchJob', pattern='4D 8B 08 4C 8B 02 48 8B D1 48 8B 0D ? ? ? ? E9 ? ? ? ?', expected=2, index=0)
+        ]),
+
+        Group(name='JobQueue', functions=[
+            Item(name='ctor_FromGroup', pattern='48 89 5C 24 10 48 89 6C 24 18 56 57 41 54 41 56 41 57 48 83 EC 20 0F B7 7A 30 4C 8B F1'),
+            Item(name='ctor_FromParams', pattern='48 89 5C 24 10 48 89 6C 24 18 56 57 41 56 48 83 EC 20 48 8D 05 ? ? ? ? 49 8B D8 48 89 01'),
+            Item(name='dtor', pattern='40 53 48 83 EC 20 80 79 30 00 48 8B D9 75 ? E8 ? ? ? ? 48 8D 4B 18 E8 ? ? ? ? 48 8D 4B 10'),
+            Item(name='Capture', pattern='48 89 5C 24 18 57 48 83  EC 20 48 8B FA 48 8B D9 E8 ? ? ? ? 48 8D 53 10 48 8B CF E8'),
+            Item(name='SyncWait', pattern='48 89 5C 24 18 57 48 83 EC 20 48 8B D9 48 83 C1 18 E8 ? ? ? ? 84 C0 75 ? 48 8D 4B 10')
+        ]),
+
         Group(name='Memory', functions=[
             Item(name='Vault::Get', pattern='48 8D 05 ? ? ? ? C3', expected=1275, index=0),
             Item(name='Vault::Alloc', pattern='48 89 5C 24 08 48 89 74 24 10 57 48 83 EC 30', expected=1964, index=5),

--- a/scripts/patterns.py
+++ b/scripts/patterns.py
@@ -204,7 +204,8 @@ def get_groups() -> List[Group]:
 
         Group(name='ResourceToken', functions=[
             Item(name='dtor', pattern='48 89 5C 24 10 57 48 83 EC 20 8B 41 58 48 8B D9 85 C0 74'),
-            Item(name='Fetch', pattern='40 53 48 83 EC 40 8B 41 58 48 8B D9 0F 29 74 24 30 0F 29 7C 24 20 85 C0 74 0A')
+            Item(name='Fetch', pattern='40 53 48 83 EC 40 8B 41 58 48 8B D9 0F 29 74 24 30 0F 29 7C 24 20 85 C0 74 0A'),
+            Item(name='OnLoaded', pattern='40 55 53 56 57 41 56 48 8D 6C 24 C9 48 81 EC F0 00 00 00 48 8B 41 08 0F 57 C0 49 8B F8 4C 8B F2')
         ]),
 
         Group(name='CRTTIScriptReferenceType', functions=[

--- a/src/JobQueue.cpp
+++ b/src/JobQueue.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/JobQueue-inl.hpp>


### PR DESCRIPTION
- Added support for callbacks
```cpp
auto loader = RED4ext::ResourceLoader::Get();
auto token = loader->LoadAsync(R"(base\vehicles\sport\v_sport1_herrera_outlaw_basic_01.ent)");
token->OnLoaded([](RED4ext::Handle<RED4ext::CResource>& aResource) {
    Log("Resource is loaded");
});
```
```cpp
auto rtti = RED4ext::CRTTISystem::Get();
rtti->AddRegisterCallback([&rtti] {
    Log("RTTI Type Registration");
});
```
- Added support for background jobs
```cpp
auto loader = RED4ext::ResourceLoader::Get();
auto token = loader->LoadAsync(R"(base\vehicles\sport\v_sport1_herrera_outlaw_basic_01.ent)");
{
    RED4ext::JobQueue queue; // Jobs in one queue are sequential
    queue.Dispatch([]{ Log("Job A-1"); });
    queue.Dispatch([]{ Log("Job A-2"); });
    queue.Dispatch([]{ Log("Job A-3"); });
    Log("Checkpoint A");
}
{
    RED4ext::JobQueue queue;
    queue.Dispatch([]{ Log("Job B-1"); });
    queue.Wait(token->job); // Suspends jobs in the queue
    queue.Dispatch([]{ Log("Job B-2"); });
    queue.Dispatch([]{ Log("Job B-3"); });
    Log("Checkpoint B");
}
```
```
[0.420] Checkpoint A
[0.420] Job A-1
[0.420] Job B-1 <-- job can start immediately, even before checkpoint B
[0.420] Checkpoint B
[0.420] Job A-2
[0.420] Job A-3 <-- all previous jobs executed at the same timestamp
[0.462] Job B-2 <-- continues when the resource is ready
[0.462] Job B-3
```
- Refactored memory utils and resource references