### PR TITLE
Optimized sorted array merging 

### DIFF
--- a/include/RED4ext/Memory/SharedPtr.hpp
+++ b/include/RED4ext/Memory/SharedPtr.hpp
@@ -218,6 +218,12 @@ public:
     {
         return reinterpret_cast<T*>(BaseType::instance);
     }
+
+    template<typename U>
+    [[nodiscard]] U* GetPtr() const noexcept
+    {
+        return reinterpret_cast<U*>(BaseType::instance);
+    }
 };
 
 template<typename T>

--- a/include/RED4ext/SortedArray.hpp
+++ b/include/RED4ext/SortedArray.hpp
@@ -246,7 +246,7 @@ private:
             insertions.emplace_back(it - begin(), item);
         }
 
-        int32_t diff = insertions.size();
+        int32_t diff = static_cast<int32_t>(insertions.size());
         if (diff == 0)
         {
             return 0;

--- a/include/RED4ext/SortedArray.hpp
+++ b/include/RED4ext/SortedArray.hpp
@@ -267,7 +267,7 @@ private:
             auto movableSpan = static_cast<uint32_t>(upperBound - lowerBound);
             if (movableSpan > 0)
             {
-                 MoveEntries(lowerBound, finalPostition + 1, movableSpan);
+                MoveEntries(lowerBound, finalPostition + 1, movableSpan);
             }
 
             *finalPostition = insertions[diff].second;

--- a/include/RED4ext/SortedArray.hpp
+++ b/include/RED4ext/SortedArray.hpp
@@ -51,6 +51,11 @@ struct SortedArray
         return Emplace(std::forward<T&&>(aItem));
     }
 
+    uint32_t Insert(const SortedArray& aOther)
+    {
+        return Merge(false, aOther);
+    }
+
     std::pair<T*, bool> InsertOrAssign(const T& aItem)
     {
         return Emplace_INTERNAL(true, std::forward<const T&>(aItem));
@@ -59,6 +64,11 @@ struct SortedArray
     std::pair<T*, bool> InsertOrAssign(T&& aItem)
     {
         return Emplace_INTERNAL(true, std::forward<T&&>(aItem));
+    }
+
+    uint32_t InsertOrAssign(const SortedArray& aOther)
+    {
+        return Merge(true, aOther);
     }
 
     T* Find(const T& aItem)
@@ -213,6 +223,60 @@ private:
         *it = std::move(tmp);
         size = newSize;
         return {it, true};
+    }
+
+    uint32_t Merge(bool insertOrAssign, const SortedArray& aOther)
+    {
+        std::vector<std::pair<size_t, const T&>> insertions;
+        insertions.reserve(aOther.size);
+
+        for (const auto& item : aOther)
+        {
+            auto it = LowerBound(item);
+
+            if (Unique && it != end() && *it == item)
+            {
+                if (insertOrAssign)
+                {
+                    *it = item;
+                }
+                continue;
+            }
+
+            insertions.emplace_back(it - begin(), item);
+        }
+
+        int32_t diff = insertions.size();
+        if (diff == 0)
+        {
+            return 0;
+        }
+
+        uint32_t newSize = size + diff;
+        if (newSize > capacity)
+        {
+            Reserve(newSize);
+        }
+
+        auto upperBound = end();
+        while (--diff >= 0)
+        {
+            auto lowerBound = begin() + insertions[diff].first;
+            auto finalPostition = lowerBound + diff;
+
+            auto movableSpan = static_cast<uint32_t>(upperBound - lowerBound);
+            if (movableSpan > 0)
+            {
+                 MoveEntries(lowerBound, finalPostition + 1, movableSpan);
+            }
+
+            *finalPostition = insertions[diff].second;
+            upperBound = lowerBound;
+        }
+
+        size = newSize;
+
+        return diff;
     }
 
     T* LowerBound(const T& aItem)

--- a/include/RED4ext/TweakDB-inl.hpp
+++ b/include/RED4ext/TweakDB-inl.hpp
@@ -303,6 +303,13 @@ RED4EXT_INLINE bool RED4ext::TweakDB::AddFlat(TweakDBID aDBID)
     return flats.Insert(aDBID).second;
 }
 
+RED4EXT_INLINE bool RED4ext::TweakDB::AddFlats(const SortedUniqueArray<TweakDBID>& aDBIDs)
+{
+    std::lock_guard<SharedMutex> _(mutex00);
+
+    return flats.Insert(aDBIDs) > 0;
+}
+
 RED4EXT_INLINE bool RED4ext::TweakDB::RemoveFlat(TweakDBID aDBID)
 {
     std::lock_guard<SharedMutex> _(mutex00);

--- a/include/RED4ext/TweakDB.hpp
+++ b/include/RED4ext/TweakDB.hpp
@@ -163,6 +163,7 @@ struct TweakDB
 
     // TweakDBID must include tdbOffset
     bool AddFlat(TweakDBID aDBID);
+    bool AddFlats(const SortedUniqueArray<TweakDBID>& aDBIDs);
     bool RemoveFlat(TweakDBID aDBID);
 
     // Multithreads may lead to undefined behavior


### PR DESCRIPTION
The main reason for this optimization is editing TweakDB. Flats are stored in a sorted unique array with over 2M entries. Flat insertion is expensive and adds up quickly when creating/cloning records with many properties. 

The new method allows batch insertions. The bigger the batch, the bigger the gain.

| N of insertions | Avg. boost |
|---|---|
| 10 | 8x |
| 100 | 25x |
| 1000 | 170x |

With this optimization applied to creating/cloning records, a real mod that adds items shows around 20x faster load times (each item record has 80-110 properties).