### PR TITLE
Various fixes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -11,4 +11,4 @@ BreakInheritanceList: BeforeComma
 KeepEmptyLinesAtTheStartOfBlocks: false
 PointerAlignment: Left
 SpaceAfterTemplateKeyword: false
-IndentRequiresClause: false
+IndentRequires: false

--- a/.clang-format
+++ b/.clang-format
@@ -11,3 +11,4 @@ BreakInheritanceList: BeforeComma
 KeepEmptyLinesAtTheStartOfBlocks: false
 PointerAlignment: Left
 SpaceAfterTemplateKeyword: false
+IndentRequiresClause: false

--- a/include/RED4ext/Addresses.hpp
+++ b/include/RED4ext/Addresses.hpp
@@ -183,6 +183,8 @@ constexpr uintptr_t ResourceReference_Reset = 0x14024BFD0 - ImageBase; // 48 83 
 constexpr uintptr_t ResourceToken_dtor = 0x14024A5E0 - ImageBase; // 48 89 5C 24 10 57 48 83 EC 20 8B 41 58 48 8B D9 85 C0 74, expected: 1, index: 0
 constexpr uintptr_t ResourceToken_Fetch = 0x14024BA00 - ImageBase; // 40 53 48 83 EC 40 8B 41 58 48 8B D9 0F 29 74 24 30 0F 29 7C 24 20 85 C0 74 0A, expected: 1, index: 0
 constexpr uintptr_t ResourceToken_OnLoaded = 0x14024B0F0 - ImageBase; // 40 55 53 56 57 41 56 48 8D 6C 24 C9 48 81 EC F0 00 00 00 48 8B 41 08 0F 57 C0 49 8B F8 4C 8B F2, expected: 1, index: 0
+constexpr uintptr_t ResourceToken_CancelUnk38 = 0x142BC3F40 - ImageBase; // 40 53 48 83 EC 20 48 8B D9 B9 08 00 00 00 E8, expected: 1, index: 0
+constexpr uintptr_t ResourceToken_DestructUnk38 = 0x1401B5670 - ImageBase; // 40 53 48 83 EC 20 48 8B D9 48 8B 49 08 48 85 C9 74 ? B8 FF FF FF FF F0 0F C1 01 83 F8 01 75, expected: 73, index: 1
 #pragma endregion
 
 #pragma region Streams

--- a/include/RED4ext/Callback.hpp
+++ b/include/RED4ext/Callback.hpp
@@ -221,6 +221,8 @@ public:
     static_assert(InlineSize >= sizeof(void*), "Buffer size can't be less than pointer size");
 
     FlexCallback(R (*aFunc)(Args...))
+        : allocator(nullptr)
+        , extendedSize(0)
     {
         using TargetType = Detail::UnboundFunctionTarget<R, Args...>;
 
@@ -231,6 +233,8 @@ public:
 
     template<typename C>
     FlexCallback(C* aContext, R (C::*aFunc)(Args...))
+        : allocator(nullptr)
+        , extendedSize(0)
     {
         using TargetType = Detail::MemberFunctionTarget<C, R, Args...>;
 
@@ -242,6 +246,8 @@ public:
     template<typename L>
     requires Detail::IsClosure<L, R, Args...>
     FlexCallback(L&& aClosure)
+        : allocator(nullptr)
+        , extendedSize(0)
     {
         using TargetType = Detail::ClosureTarget<L, R, Args...>;
 

--- a/include/RED4ext/RTTITypes.hpp
+++ b/include/RED4ext/RTTITypes.hpp
@@ -412,17 +412,16 @@ struct CRTTIBaseArrayType : CBaseRTTIType
     virtual uint32_t GetLength(ScriptInstance aInstance) const = 0;                         // D0
     virtual int32_t GetMaxLength() const = 0;                                               // D8 ret -1
     virtual ScriptInstance GetElement(ScriptInstance aInstance, uint32_t aIndex) const = 0; // E0
-    virtual ScriptInstance GetValuePointer(ScriptInstance aInstance,
-                                           uint32_t aIndex) const = 0; // E8 Same func at 0xE0 ?
-    virtual int32_t sub_F0(ScriptInstance aInstance, int32_t aIndex, ScriptInstance aElement) = 0; // F0
-    virtual bool RemoveAt(ScriptInstance aInstance, int32_t aIndex) = 0;                           // F8
+    virtual ScriptInstance sub_E8(ScriptInstance aInstance, uint32_t aIndex) const = 0;     // E8 Same as E0
+    virtual int32_t Add(ScriptInstance aInstance, int32_t aCount) const = 0;                // F0
+    virtual bool RemoveAt(ScriptInstance aInstance, int32_t aIndex) const = 0;              // F8
     // [1, 2, 3]
-    // RTTI->InsertAt(aIndex: 1);
-    // [1, 2 (freed/destroyed), 2, 3]
-    // InnerRTTI->Assign(RTTI->GetElement(aIndex: 1), newValue)
+    // ArrayRTTI->InsertAt(aIndex: 1);
+    // [1, (free), 2, 3]
+    // InnerRTTI->Assign(ArrayRTTI->GetElement(1), newValue)
     // [1, newValue, 2, 3]
-    virtual bool InsertAt(ScriptInstance aInstance, int32_t aIndex) = 0; // 100
-    virtual bool Resize(ScriptInstance aInstance, uint32_t aSize) = 0;   // 108
+    virtual bool InsertAt(ScriptInstance aInstance, int32_t aIndex) const = 0;              // 100
+    virtual bool Resize(ScriptInstance aInstance, uint32_t aSize) const = 0;                // 108
 
     CBaseRTTIType* innerType; // 10
 };

--- a/include/RED4ext/RTTITypes.hpp
+++ b/include/RED4ext/RTTITypes.hpp
@@ -420,8 +420,8 @@ struct CRTTIBaseArrayType : CBaseRTTIType
     // [1, (free), 2, 3]
     // InnerRTTI->Assign(ArrayRTTI->GetElement(1), newValue)
     // [1, newValue, 2, 3]
-    virtual bool InsertAt(ScriptInstance aInstance, int32_t aIndex) const = 0;              // 100
-    virtual bool Resize(ScriptInstance aInstance, uint32_t aSize) const = 0;                // 108
+    virtual bool InsertAt(ScriptInstance aInstance, int32_t aIndex) const = 0; // 100
+    virtual bool Resize(ScriptInstance aInstance, uint32_t aSize) const = 0;   // 108
 
     CBaseRTTIType* innerType; // 10
 };

--- a/include/RED4ext/ResourceLoader.hpp
+++ b/include/RED4ext/ResourceLoader.hpp
@@ -28,10 +28,16 @@ struct ResourceToken
 
     ~ResourceToken()
     {
-        using Destruct_t = void (*)(ResourceToken*);
-        RelocFunc<Destruct_t> func(Addresses::ResourceToken_dtor);
+        if (!IsFinished())
+        {
+            using CancelUnk38_t = void (*)(void*);
+            RelocFunc<CancelUnk38_t> CancelUnk38(Addresses::ResourceToken_CancelUnk38);
+            CancelUnk38(unk38);
+        }
 
-        func(this);
+        using DestructUnk38_t = void (*)(void**);
+        RelocFunc<DestructUnk38_t> DestructUnk38(Addresses::ResourceToken_DestructUnk38);
+        DestructUnk38(&unk38);
     }
 
     /**
@@ -95,8 +101,8 @@ struct ResourceToken
     DynArray<SharedPtr<ResourceToken<>>> dependencies; // 10
     SharedMutex lock;                                  // 20
     Handle<T> resource;                                // 28
-    uint64_t unk38;                                    // 38 - SharedPtr<Unk38>
-    uint64_t unk40;                                    // 40
+    void* unk38;                                       // 38 - SharedPtr<Unk38>.instance
+    void* unk40;                                       // 40 - SharedPtr<Unk38>.refCount
     ResourcePath path;                                 // 48
     JobHandle job;                                     // 50
     volatile int32_t finished;                         // 58

--- a/include/RED4ext/ResourceLoader.hpp
+++ b/include/RED4ext/ResourceLoader.hpp
@@ -66,7 +66,7 @@ struct ResourceToken
      *
      * @return The loaded resource.
      */
-    [[nodiscard]] Handle<T>& Get() const noexcept
+    [[nodiscard]] Handle<T>& Get() noexcept
     {
         return resource;
     }
@@ -86,23 +86,17 @@ struct ResourceToken
         return error;
     }
 
-    [[nodiscard]] inline operator T*() const noexcept
+    [[nodiscard]] inline operator T*() noexcept
     {
         return resource.GetPtr();
     }
-
-    struct Unk38
-    {
-        using AllocatorType = Memory::EngineAllocator;
-        uint8_t unk0[0x78];
-    };
-    RED4EXT_ASSERT_SIZE(Unk38, 0x78);
 
     WeakPtr<ResourceToken<T>> self;                    // 00
     DynArray<SharedPtr<ResourceToken<>>> dependencies; // 10
     SharedMutex lock;                                  // 20
     Handle<T> resource;                                // 28
-    SharedPtr<Unk38> unk38;                            // 38
+    uint64_t unk38;                                    // 38 - SharedPtr<Unk38>
+    uint64_t unk40;                                    // 40
     ResourcePath path;                                 // 48
     JobHandle job;                                     // 50
     volatile int32_t finished;                         // 58

--- a/include/RED4ext/ResourceReference.hpp
+++ b/include/RED4ext/ResourceReference.hpp
@@ -159,6 +159,18 @@ struct ResourceAsyncReference
         aOther.path = ResourcePath();
     }
 
+    ResourceAsyncReference& operator=(const ResourceAsyncReference& aRhs) noexcept
+    {
+        path = aRhs.path;
+        return *this;
+    }
+
+    ResourceAsyncReference& operator=(ResourceAsyncReference&& aRhs) noexcept
+    {
+        path = std::move(aRhs.path);
+        return *this;
+    }
+
     [[nodiscard]] ResourceReference<T> Resolve() const noexcept
     {
         return {path};

--- a/include/RED4ext/Scripting/CProperty.hpp
+++ b/include/RED4ext/Scripting/CProperty.hpp
@@ -101,7 +101,6 @@ struct CProperty
         }
     }
 
-private:
     template<typename T>
     T* GetValuePtr(ScriptInstance aInstance) const
     {

--- a/scripts/patterns.py
+++ b/scripts/patterns.py
@@ -212,7 +212,9 @@ def get_groups() -> List[Group]:
         Group(name='ResourceToken', functions=[
             Item(name='dtor', pattern='48 89 5C 24 10 57 48 83 EC 20 8B 41 58 48 8B D9 85 C0 74'),
             Item(name='Fetch', pattern='40 53 48 83 EC 40 8B 41 58 48 8B D9 0F 29 74 24 30 0F 29 7C 24 20 85 C0 74 0A'),
-            Item(name='OnLoaded', pattern='40 55 53 56 57 41 56 48 8D 6C 24 C9 48 81 EC F0 00 00 00 48 8B 41 08 0F 57 C0 49 8B F8 4C 8B F2')
+            Item(name='OnLoaded', pattern='40 55 53 56 57 41 56 48 8D 6C 24 C9 48 81 EC F0 00 00 00 48 8B 41 08 0F 57 C0 49 8B F8 4C 8B F2'),
+            Item(name='CancelUnk38', pattern='40 53 48 83 EC 20 48 8B D9 B9 08 00 00 00 E8'),
+            Item(name='DestructUnk38', pattern='40 53 48 83 EC 20 48 8B D9 48 8B 49 08 48 85 C9 74 ? B8 FF FF FF FF F0 0F C1 01 83 F8 01 75', expected=73, index=1)
         ]),
 
         Group(name='CRTTIScriptReferenceType', functions=[


### PR DESCRIPTION
- Updated `CRTTIBaseArrayType` vft
- Fixed `FlexCallback` ctor to properly initialize allocator ptr
- Removed `ResourceToken::Unk38` as it can cause issues until fully decoded
- Removed unneeded `const` from `ResourceToken`
- Added assignment operators for `ResourceAsyncReference`
- Made `CProperty::GetValuePtr()` public
