### PR TITLE
Adds Scripts to SDK for loading redscript through RED4ext

### DIFF
--- a/include/RED4ext/Api/Sdk.hpp
+++ b/include/RED4ext/Api/Sdk.hpp
@@ -44,6 +44,11 @@ using GameStates = v0::GameStates;
  * @brief The latest game state type.
  */
 using GameState = v0::GameState;
+
+/**
+ * @brief The latest game state type.
+ */
+using Scripts = v0::Scripts;
 } // namespace RED4ext
 
 /*

--- a/include/RED4ext/Api/v0/Scripts.hpp
+++ b/include/RED4ext/Api/v0/Scripts.hpp
@@ -33,6 +33,6 @@ struct Scripts
      *     return true;
      * }
      */
-    bool (*Add)(PluginHandle aHandle, const char* aPath);
+    bool (*Add)(PluginHandle aHandle, const wchar_t* aPath);
 };
 } // namespace RED4ext::v0

--- a/include/RED4ext/Api/v0/Scripts.hpp
+++ b/include/RED4ext/Api/v0/Scripts.hpp
@@ -32,6 +32,6 @@ struct Scripts
      *     return true;
      * }
      */
-    bool (*Add)(PluginHandle aHandle, std::filesystem::path aPath);
+    bool (*Add)(PluginHandle aHandle, std::filesystem::path &aPath);
 };
 } // namespace RED4ext::v0

--- a/include/RED4ext/Api/v0/Scripts.hpp
+++ b/include/RED4ext/Api/v0/Scripts.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <filesystem>
 #include <RED4ext/Api/PluginHandle.hpp>
+#include <filesystem>
+
 
 namespace RED4ext::v0
 {
@@ -32,6 +33,6 @@ struct Scripts
      *     return true;
      * }
      */
-    bool (*Add)(PluginHandle aHandle, const char *aPath);
+    bool (*Add)(PluginHandle aHandle, const char* aPath);
 };
 } // namespace RED4ext::v0

--- a/include/RED4ext/Api/v0/Scripts.hpp
+++ b/include/RED4ext/Api/v0/Scripts.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <RED4ext/Api/PluginHandle.hpp>
+
+namespace RED4ext::v0
+{
+struct Scripts
+{
+    /**
+     * @brief Attach a hook.
+     *
+     * @param[in]   aHandle     The plugin's handle.
+     * @param[in]   aPath       The path to be added to the redscript compilation - can be a folder or a .reds file
+     *
+     * @return Returns true if the path was added is attached, false otherwise.
+     *
+     * @example
+     *
+     * RED4EXT_C_EXPORT bool RED4EXT_CALL Main(RED4ext::PluginHandle aHandle, RED4ext::EMainReason aReason, const
+     * RED4ext::RED4ext* aRED4ext)
+     * {
+     *     switch (aReason)
+     *     {
+     *     case RED4ext::EMainReason::Load:
+     *     {
+     *         aRED4ext->scripts->Add(aHandle, "my_mod.reds");
+     *         break;
+     *     }
+     *     }
+     *
+     *     return true;
+     * }
+     */
+    bool (*Add)(PluginHandle aHandle, std::filesystem::path aPath);
+};
+} // namespace RED4ext::v0

--- a/include/RED4ext/Api/v0/Scripts.hpp
+++ b/include/RED4ext/Api/v0/Scripts.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <filesystem>
 #include <RED4ext/Api/PluginHandle.hpp>
 
 namespace RED4ext::v0

--- a/include/RED4ext/Api/v0/Scripts.hpp
+++ b/include/RED4ext/Api/v0/Scripts.hpp
@@ -18,13 +18,13 @@ struct Scripts
      * @example
      *
      * RED4EXT_C_EXPORT bool RED4EXT_CALL Main(RED4ext::PluginHandle aHandle, RED4ext::EMainReason aReason, const
-     * RED4ext::RED4ext* aRED4ext)
+     * RED4ext::Sdk* aSdk)
      * {
      *     switch (aReason)
      *     {
      *     case RED4ext::EMainReason::Load:
      *     {
-     *         aRED4ext->scripts->Add(aHandle, "my_mod.reds");
+     *         aSdk->scripts->Add(aHandle, "my_mod.reds");
      *         break;
      *     }
      *     }
@@ -32,6 +32,6 @@ struct Scripts
      *     return true;
      * }
      */
-    bool (*Add)(PluginHandle aHandle, std::filesystem::path &aPath);
+    bool (*Add)(PluginHandle aHandle, const char *aPath);
 };
 } // namespace RED4ext::v0

--- a/include/RED4ext/Api/v0/Scripts.hpp
+++ b/include/RED4ext/Api/v0/Scripts.hpp
@@ -3,7 +3,6 @@
 #include <RED4ext/Api/PluginHandle.hpp>
 #include <filesystem>
 
-
 namespace RED4ext::v0
 {
 struct Scripts

--- a/include/RED4ext/Api/v0/Sdk.hpp
+++ b/include/RED4ext/Api/v0/Sdk.hpp
@@ -4,6 +4,7 @@
 #include <RED4ext/Api/v0/GameStates.hpp>
 #include <RED4ext/Api/v0/Hooking.hpp>
 #include <RED4ext/Api/v0/Logger.hpp>
+#include <RED4ext/Api/v0/Scripts.hpp>
 
 namespace RED4ext::v0
 {
@@ -21,5 +22,6 @@ struct Sdk
     Logger* logger;
     Hooking* hooking;
     GameStates* gameStates;
+    Scripts* scripts;
 };
 } // namespace RED4ext::v0


### PR DESCRIPTION
Paired with https://github.com/WopsS/RED4ext/pull/21

> Paths can be added via the Scripts::Add function in the sdk, during Load:
>
>     aSdk->scripts->Add(aHandle, L"module.reds");
>
> Paths can either directories or files (handled by scc), relative to the plugin's folder, or absolute (mainly for testing/development).
>
> This will also force script compilation when REDmods are enabled, which will cause double-compilation if cybercmd is installed - cybercmd is no longer needed for this scenario.