### PR TITLE
Fixed HashMap + more TransactionSystem

### DIFF
--- a/include/RED4ext/HashMap.hpp
+++ b/include/RED4ext/HashMap.hpp
@@ -211,33 +211,23 @@ struct HashMap
 
     bool Remove(const K& aKey)
     {
-        // This function is guessed based on how the other functions are implemented
-        // Couldn't easily find it in the game -Sombra
-
         if (size == 0)
             return false;
 
         uint32_t hashedKey = Hasher{}(aKey);
-        uint32_t idx = indexTable[hashedKey % capacity];
-        while (idx != INVALID_INDEX)
+        uint32_t* idx = &indexTable[hashedKey % capacity];
+        while (*idx != INVALID_INDEX)
         {
-            Node* prevNode = nullptr;
-            Node* node = &nodeList.nodes[idx];
+            Node* node = &nodeList.nodes[*idx];
             if (node->hashedKey == hashedKey && node->key == aKey)
             {
-                if (prevNode == nullptr)
-                    indexTable[hashedKey % capacity] = node->next;
-                else
-                    prevNode->next = node->next;
-
-                node->next = nodeList.nextIdx;
-                nodeList.nextIdx = static_cast<uint32_t>(node - nodeList.nodes);
+                *idx = node->next;
                 node->~Node();
+                nodeList.nextIdx = static_cast<uint32_t>(node - nodeList.nodes);
                 --size;
                 return true;
             }
-            prevNode = node;
-            idx = node->next;
+            idx = &node->next;
         }
 
         return false;

--- a/include/RED4ext/Scripting/Natives/Generated/game/IAttachmentSlotsListener.hpp
+++ b/include/RED4ext/Scripting/Natives/Generated/game/IAttachmentSlotsListener.hpp
@@ -4,6 +4,16 @@
 
 // This file is generated from the Game's Reflection data
 
+#include <RED4ext/Scripting/Natives/gameIAttachmentSlotsListener.hpp>
+
+namespace RED4ext
+{
+RED4EXT_ASSERT_SIZE(game::IAttachmentSlotsListener, 0x40);
+using gameIAttachmentSlotsListener = game::IAttachmentSlotsListener;
+using AttachmentSlotsListener = game::IAttachmentSlotsListener;
+} // namespace RED4ext
+
+/*
 #include <cstdint>
 #include <RED4ext/Common.hpp>
 #include <RED4ext/Scripting/IScriptable.hpp>
@@ -23,5 +33,6 @@ RED4EXT_ASSERT_SIZE(IAttachmentSlotsListener, 0x40);
 using gameIAttachmentSlotsListener = game::IAttachmentSlotsListener;
 using AttachmentSlotsListener = game::IAttachmentSlotsListener;
 } // namespace RED4ext
+*/
 
 // clang-format on

--- a/include/RED4ext/Scripting/Natives/gameIAttachmentSlotsListener-inl.hpp
+++ b/include/RED4ext/Scripting/Natives/gameIAttachmentSlotsListener-inl.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/Scripting/Natives/gameIAttachmentSlotsListener.hpp>
+#endif
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemEquippingStarted(const ItemID& aItemID,
+                                                                                    TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemEquippingCanceled(const ItemID& aItemID,
+                                                                                     TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemEquipped(const ItemID& aItemID, TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemEquippedComplete(const ItemID& aItemID,
+                                                                                    TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemEquippedVisual(const ItemID& aItemID,
+                                                                                  TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemUnequippingStarted(const ItemID& aItemID,
+                                                                                      TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemUnequippingCanceled(const ItemID& aItemID,
+                                                                                       TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemUnequipped(const ItemID& aItemID, TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnItemUnequippedComplete(const ItemID& aItemID,
+                                                                                      TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnAttachmentPreRefreshed(const ItemID& aItemID,
+                                                                                      TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnAttachmentRefreshed(const ItemID& aItemID,
+                                                                                   TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnChangeAppearanceComplete(const ItemID& aItemID,
+                                                                                        TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}
+
+RED4EXT_INLINE void RED4ext::game::IAttachmentSlotsListener::OnChangeAppearanceCanceled(const ItemID& aItemID,
+                                                                                        TweakDBID aSlotID)
+{
+    RED4EXT_UNUSED_PARAMETER(aItemID);
+    RED4EXT_UNUSED_PARAMETER(aSlotID);
+}

--- a/include/RED4ext/Scripting/Natives/gameIAttachmentSlotsListener.hpp
+++ b/include/RED4ext/Scripting/Natives/gameIAttachmentSlotsListener.hpp
@@ -12,22 +12,26 @@ struct IAttachmentSlotsListener : IScriptable
     static constexpr const char* NAME = "gameIAttachmentSlotsListener";
     static constexpr const char* ALIAS = "AttachmentSlotsListener";
 
-    virtual void OnItemEquippingStarted(ItemID& aItemID, TweakDBID aSlotID){};     // 110
-    virtual void OnItemEquippingCanceled(ItemID& aItemID, TweakDBID aSlotID){};    // 118
-    virtual void OnItemEquipped(ItemID& aItemID, TweakDBID aSlotID){};             // 120
-    virtual void OnItemEquippedComplete(ItemID& aItemID, TweakDBID aSlotID){};     // 128
-    virtual void OnItemEquippedVisual(ItemID& aItemID, TweakDBID aSlotID){};       // 130
-    virtual void OnItemUnequippingStarted(ItemID& aItemID, TweakDBID aSlotID){};   // 138
-    virtual void OnItemUnequippingCanceled(ItemID& aItemID, TweakDBID aSlotID){};  // 140
-    virtual void OnItemUnequipped(ItemID& aItemID, TweakDBID aSlotID){};           // 148
-    virtual void OnItemUnequippedComplete(ItemID& aItemID, TweakDBID aSlotID){};   // 150
-    virtual void OnAttachmentPreRefreshed(ItemID& aItemID, TweakDBID aSlotID){};   // 158
-    virtual void OnAttachmentRefreshed(ItemID& aItemID, TweakDBID aSlotID){};      // 160
-    virtual void OnChangeAppearanceComplete(ItemID& aItemID, TweakDBID aSlotID){}; // 168
-    virtual void OnChangeAppearanceCanceled(ItemID& aItemID, TweakDBID aSlotID){}; // 170
+    virtual void OnItemEquippingStarted(const ItemID& aItemID, TweakDBID aSlotID);     // 110
+    virtual void OnItemEquippingCanceled(const ItemID& aItemID, TweakDBID aSlotID);    // 118
+    virtual void OnItemEquipped(const ItemID& aItemID, TweakDBID aSlotID);             // 120
+    virtual void OnItemEquippedComplete(const ItemID& aItemID, TweakDBID aSlotID);     // 128
+    virtual void OnItemEquippedVisual(const ItemID& aItemID, TweakDBID aSlotID);       // 130
+    virtual void OnItemUnequippingStarted(const ItemID& aItemID, TweakDBID aSlotID);   // 138
+    virtual void OnItemUnequippingCanceled(const ItemID& aItemID, TweakDBID aSlotID);  // 140
+    virtual void OnItemUnequipped(const ItemID& aItemID, TweakDBID aSlotID);           // 148
+    virtual void OnItemUnequippedComplete(const ItemID& aItemID, TweakDBID aSlotID);   // 150
+    virtual void OnAttachmentPreRefreshed(const ItemID& aItemID, TweakDBID aSlotID);   // 158
+    virtual void OnAttachmentRefreshed(const ItemID& aItemID, TweakDBID aSlotID);      // 160
+    virtual void OnChangeAppearanceComplete(const ItemID& aItemID, TweakDBID aSlotID); // 168
+    virtual void OnChangeAppearanceCanceled(const ItemID& aItemID, TweakDBID aSlotID); // 170
 };
 RED4EXT_ASSERT_SIZE(IAttachmentSlotsListener, 0x40);
 } // namespace game
 using gameIAttachmentSlotsListener = game::IAttachmentSlotsListener;
 using AttachmentSlotsListener = game::IAttachmentSlotsListener;
 } // namespace RED4ext
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/Scripting/Natives/gameIAttachmentSlotsListener-inl.hpp>
+#endif

--- a/include/RED4ext/Scripting/Natives/gameIAttachmentSlotsListener.hpp
+++ b/include/RED4ext/Scripting/Natives/gameIAttachmentSlotsListener.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <RED4ext/Common.hpp>
+#include <RED4ext/Scripting/IScriptable.hpp>
+
+namespace RED4ext
+{
+namespace game
+{
+struct IAttachmentSlotsListener : IScriptable
+{
+    static constexpr const char* NAME = "gameIAttachmentSlotsListener";
+    static constexpr const char* ALIAS = "AttachmentSlotsListener";
+
+    virtual void OnItemEquippingStarted(ItemID& aItemID, TweakDBID aSlotID){};     // 110
+    virtual void OnItemEquippingCanceled(ItemID& aItemID, TweakDBID aSlotID){};    // 118
+    virtual void OnItemEquipped(ItemID& aItemID, TweakDBID aSlotID){};             // 120
+    virtual void OnItemEquippedComplete(ItemID& aItemID, TweakDBID aSlotID){};     // 128
+    virtual void OnItemEquippedVisual(ItemID& aItemID, TweakDBID aSlotID){};       // 130
+    virtual void OnItemUnequippingStarted(ItemID& aItemID, TweakDBID aSlotID){};   // 138
+    virtual void OnItemUnequippingCanceled(ItemID& aItemID, TweakDBID aSlotID){};  // 140
+    virtual void OnItemUnequipped(ItemID& aItemID, TweakDBID aSlotID){};           // 148
+    virtual void OnItemUnequippedComplete(ItemID& aItemID, TweakDBID aSlotID){};   // 150
+    virtual void OnAttachmentPreRefreshed(ItemID& aItemID, TweakDBID aSlotID){};   // 158
+    virtual void OnAttachmentRefreshed(ItemID& aItemID, TweakDBID aSlotID){};      // 160
+    virtual void OnChangeAppearanceComplete(ItemID& aItemID, TweakDBID aSlotID){}; // 168
+    virtual void OnChangeAppearanceCanceled(ItemID& aItemID, TweakDBID aSlotID){}; // 170
+};
+RED4EXT_ASSERT_SIZE(IAttachmentSlotsListener, 0x40);
+} // namespace game
+using gameIAttachmentSlotsListener = game::IAttachmentSlotsListener;
+using AttachmentSlotsListener = game::IAttachmentSlotsListener;
+} // namespace RED4ext

--- a/include/RED4ext/Scripting/Natives/gameITransactionSystem.hpp
+++ b/include/RED4ext/Scripting/Natives/gameITransactionSystem.hpp
@@ -22,8 +22,8 @@ struct ITransactionSystem : IGameSystem
     virtual void sub_1B0() = 0;                                                                                  // 1B0
     virtual void sub_1B8() = 0;                                                                                  // 1B8
     virtual void sub_1C0() = 0;                                                                                  // 1C0
-    virtual CName* GetItemAppearance(CName& aAppearance, IScriptable* aOwner, ItemID& aItemID) = 0;              // 1C8
-    virtual void ResetItemAppearance(IScriptable* aOwner, ItemID& aItemID) = 0;                                  // 1D0
+    virtual CName* GetItemAppearance(CName& aAppearance, IScriptable* aOwner, const ItemID& aItemID) = 0;        // 1C8
+    virtual void ResetItemAppearance(IScriptable* aOwner, const ItemID& aItemID) = 0;                            // 1D0
     virtual void sub_1D8() = 0;                                                                                  // 1D8
     virtual void sub_1E0() = 0;                                                                                  // 1E0
     virtual void sub_1E8() = 0;                                                                                  // 1E8
@@ -113,10 +113,11 @@ struct ITransactionSystem : IGameSystem
     virtual void sub_488() = 0;                                                                                  // 488
     virtual void sub_490() = 0;                                                                                  // 490
     virtual void sub_498() = 0;                                                                                  // 498
-    virtual bool MatchVisualTagByItemID(ItemID& aItemID, const Handle<IScriptable>& aOwner, CName aTag) = 0;     // 4A0
-    virtual bool MatchVisualTag(const Handle<IScriptable>& aItem, CName aTag, bool aUseDefaultAppearance) = 0;   // 4A8
-    virtual void sub_4B0() = 0;                                                                                  // 4B0
-    virtual void sub_4B8() = 0;                                                                                  // 4B8
+    virtual bool MatchVisualTagByItemID(const ItemID& aItemID, const Handle<IScriptable>& aOwner,
+                                        CName aTag) = 0;                                                       // 4A0
+    virtual bool MatchVisualTag(const Handle<IScriptable>& aItem, CName aTag, bool aUseDefaultAppearance) = 0; // 4A8
+    virtual void sub_4B0() = 0;                                                                                // 4B0
+    virtual void sub_4B8() = 0;                                                                                // 4B8
 };
 RED4EXT_ASSERT_SIZE(ITransactionSystem, 0x48);
 } // namespace game

--- a/include/RED4ext/Scripting/Natives/gameITransactionSystem.hpp
+++ b/include/RED4ext/Scripting/Natives/gameITransactionSystem.hpp
@@ -2,6 +2,7 @@
 
 #include <RED4ext/Common.hpp>
 #include <RED4ext/Scripting/Natives/Generated/game/AttachmentSlotData.hpp>
+#include <RED4ext/Scripting/Natives/Generated/game/IAttachmentSlotsListener.hpp>
 #include <RED4ext/Scripting/Natives/Generated/game/IGameSystem.hpp>
 #include <RED4ext/Scripting/Natives/Generated/game/ItemObject.hpp>
 #include <RED4ext/Scripting/Natives/Generated/game/Object.hpp>
@@ -22,7 +23,7 @@ struct ITransactionSystem : IGameSystem
     virtual void sub_1B8() = 0;                                                                                  // 1B8
     virtual void sub_1C0() = 0;                                                                                  // 1C0
     virtual CName* GetItemAppearance(CName& aAppearance, IScriptable* aOwner, ItemID& aItemID) = 0;              // 1C8
-    virtual void sub_1D0() = 0;                                                                                  // 1D0
+    virtual void ResetItemAppearance(IScriptable* aOwner, ItemID& aItemID) = 0;                                  // 1D0
     virtual void sub_1D8() = 0;                                                                                  // 1D8
     virtual void sub_1E0() = 0;                                                                                  // 1E0
     virtual void sub_1E8() = 0;                                                                                  // 1E8
@@ -90,9 +91,9 @@ struct ITransactionSystem : IGameSystem
     virtual void sub_3D8() = 0;                                                                                  // 3D8
     virtual void sub_3E0() = 0;                                                                                  // 3E0
     virtual void sub_3E8() = 0;                                                                                  // 3E8
-    virtual bool GetItemInSlot(IScriptable* aOwner, TweakDBID aSlotID, Handle<IScriptable>& aItem) = 0;          // 3F0
+    virtual bool GetItemInSlot(IScriptable* aOwner, TweakDBID aSlotID, const Handle<IScriptable>& aItem) = 0;    // 3F0
     virtual void sub_3F8() = 0;                                                                                  // 3F8
-    virtual void sub_400() = 0;                                                                                  // 400
+    virtual void GetSlotDataList(IScriptable* aOwner, DynArray<AttachmentSlotData>& aList) = 0;                  // 400
     virtual void sub_408() = 0;                                                                                  // 408
     virtual void sub_410() = 0;                                                                                  // 410
     virtual AttachmentSlotData* FindSlotData(IScriptable* aOwner, AttachmentSlotDataPredicate&& aPredicate) = 0; // 418
@@ -104,16 +105,16 @@ struct ITransactionSystem : IGameSystem
     virtual void sub_448() = 0;                                                                                  // 448
     virtual void sub_450() = 0;                                                                                  // 450
     virtual void sub_458() = 0;                                                                                  // 458
-    virtual void sub_460() = 0;                                                                                  // 460
-    virtual void sub_468() = 0;                                                                                  // 468
+    virtual void RegisterSlotListener(IScriptable* aOwner, Handle<IAttachmentSlotsListener> aListener) = 0;      // 460
+    virtual void UnregisterSlotListener(IScriptable* aOwner, Handle<IAttachmentSlotsListener> aListener) = 0;    // 468
     virtual void sub_470() = 0;                                                                                  // 470
     virtual void sub_478() = 0;                                                                                  // 478
     virtual void sub_480() = 0;                                                                                  // 480
     virtual void sub_488() = 0;                                                                                  // 488
     virtual void sub_490() = 0;                                                                                  // 490
     virtual void sub_498() = 0;                                                                                  // 498
-    virtual bool MatchVisualTagByItemID(ItemID& aItemID, Handle<IScriptable>& aOwner, CName aTag) = 0;           // 4A0
-    virtual bool MatchVisualTag(Handle<IScriptable>& aItem, CName aTag, bool aUseDefaultAppearance) = 0;         // 4A8
+    virtual bool MatchVisualTagByItemID(ItemID& aItemID, const Handle<IScriptable>& aOwner, CName aTag) = 0;     // 4A0
+    virtual bool MatchVisualTag(const Handle<IScriptable>& aItem, CName aTag, bool aUseDefaultAppearance) = 0;   // 4A8
     virtual void sub_4B0() = 0;                                                                                  // 4B0
     virtual void sub_4B8() = 0;                                                                                  // 4B8
 };

--- a/src/Scripting/Natives/gameIAttachmentSlotsListener.cpp
+++ b/src/Scripting/Natives/gameIAttachmentSlotsListener.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/Scripting/Natives/gameIAttachmentSlotsListener-inl.hpp>


### PR DESCRIPTION
Found that HashMap deletions are broken.
I was lucky to find an implementation in TransactionSystem and adjusted ours accourdigly.
Sombra's implementation was pretty accurate except one tiny mistake:
```cpp
while (idx != INVALID_INDEX)
{
    Node* prevNode = nullptr; // should've been outside of loop :)
    Node* node = &nodes[idx];
    ...
    prevNode = node;
    idx = node->next;
}
```
For reference their implementation can be found here:
`83 7D ? ? 74 ? 33 D2 8B C3 F7 75 ? 48 8B 45 ? 8B 0C 90 48 8D 14 90 83 F9 ? 74 ? 44 8B 45 ? 4C 8B 4D`

![HashMap3](https://github.com/WopsS/RED4ext.SDK/assets/4366745/51516aca-40d8-4b06-a650-4be66a45c0df)