### PR TITLE
Fix compilation of TLS-inl.hpp

### DIFF
--- a/include/RED4ext/TLS-inl.hpp
+++ b/include/RED4ext/TLS-inl.hpp
@@ -4,6 +4,8 @@
 #include <RED4ext/TLS.hpp>
 #endif
 
+#include <intrin.h>
+
 RED4EXT_INLINE RED4ext::TLS* RED4ext::TLS::Get()
 {
     return *reinterpret_cast<TLS**>(__readgsqword(0x58));


### PR DESCRIPTION
When trying to compile CyberEngineTweaks with the latest patch-2.0 branch, the compilation fails with
```
error: TLS.cpp
vendor\RED4ext.SDK\include\RED4ext/TLS-inl.hpp(9): error C3861: '__readgsqword': identifier not found
```

Including `intrin.h` solves that.