### PR TITLE
fix: fix clang compat

### DIFF
--- a/include/RED4ext/JobQueue-inl.hpp
+++ b/include/RED4ext/JobQueue-inl.hpp
@@ -154,7 +154,7 @@ RED4EXT_INLINE void RED4ext::JobQueue::Wait(const JobHandle& aJob)
     unk10.Join(aJob);
 }
 
-RED4EXT_INLINE [[nodiscard]] RED4ext::JobHandle RED4ext::JobQueue::Capture()
+[[nodiscard]] RED4EXT_INLINE RED4ext::JobHandle RED4ext::JobQueue::Capture()
 {
     using func_t = JobHandle* (*)(JobQueue*, JobHandle*);
     static UniversalRelocFunc<func_t> func(Detail::AddressHashes::JobQueue_Capture);


### PR DESCRIPTION
fixes an issue with the code relying on msvc specific behavior in 2 places
- one [[nodiscard]] attribute
- I think `GetAllocator` relies on a bug in two-phase lookup in MSVC: https://blog.llvm.org/2009/12/dreaded-two-phase-name-lookup.html