### PR TITLE
Rename SharedMutex and introduce Mutex

### DIFF
--- a/include/RED4ext/Buffer.hpp
+++ b/include/RED4ext/Buffer.hpp
@@ -72,7 +72,7 @@ struct DeferredDataBuffer
     uint64_t unk48;                // 48
     uint32_t unk50;                // 50
     DeferredDataBufferState state; // 54
-    SharedMutex lock;              // 55
+    SharedSpinLock lock;           // 55
     uint16_t unk56;                // 56
 };
 RED4EXT_ASSERT_SIZE(DeferredDataBuffer, 0x58);

--- a/include/RED4ext/GameEngine.hpp
+++ b/include/RED4ext/GameEngine.hpp
@@ -134,7 +134,7 @@ struct CBaseEngine
     int8_t unk34;                              // 34
     uint64_t scriptsTimestamp;                 // 38
     int8_t unk40;                              // 40
-    SharedMutex terminationLock;               // 41
+    SharedSpinLock terminationLock;            // 41
     int32_t unk44;                             // 44
     int8_t terminating;                        // 48
     int8_t unk49;                              // 49

--- a/include/RED4ext/Memory/Pool.hpp
+++ b/include/RED4ext/Memory/Pool.hpp
@@ -5,7 +5,7 @@
 
 #include <RED4ext/Common.hpp>
 #include <RED4ext/Hashing/FNV1a.hpp>
-#include <RED4ext/SharedMutex.hpp>
+#include <RED4ext/SharedSpinLock.hpp>
 
 namespace RED4ext::Memory
 {
@@ -47,7 +47,7 @@ struct PoolRegistry
 {
     static constexpr auto MaxPoolCount = 768;
 
-    SharedMutex nodesLock;        // 00
+    SharedSpinLock nodesLock;     // 00
     PoolInfo nodes[MaxPoolCount]; // 08
 
     template<typename T = PoolInfo>
@@ -60,7 +60,7 @@ struct PoolRegistry
     template<typename T = PoolInfo>
     T* Get(uint32_t aHandle)
     {
-        std::shared_lock<SharedMutex> _(nodesLock);
+        std::shared_lock<SharedSpinLock> _(nodesLock);
 
         /* Did not find anything to do this in O(1), could do it with some caching, but a separate struct would have to
          * be mantained, which is an overkill for this. Code that is using this should cache the value in a static

--- a/include/RED4ext/Mutex-inl.hpp
+++ b/include/RED4ext/Mutex-inl.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/Mutex.hpp>
+#endif
+
+RED4EXT_INLINE RED4ext::Mutex::Mutex()
+{
+    InitializeCriticalSection(&cs);
+}
+
+RED4EXT_INLINE void RED4ext::Mutex::Lock()
+{
+    EnterCriticalSection(&cs);
+}
+
+RED4EXT_INLINE void RED4ext::Mutex::Unlock()
+{
+    LeaveCriticalSection(&cs);
+}
+
+RED4EXT_INLINE void RED4ext::Mutex::lock()
+{
+    Lock();
+}
+
+RED4EXT_INLINE void RED4ext::Mutex::unlock()
+{
+    Unlock();
+}

--- a/include/RED4ext/Mutex-inl.hpp
+++ b/include/RED4ext/Mutex-inl.hpp
@@ -6,17 +6,17 @@
 
 RED4EXT_INLINE RED4ext::Mutex::Mutex()
 {
-    InitializeCriticalSection(&cs);
+    InitializeCriticalSection(&m_cs);
 }
 
 RED4EXT_INLINE void RED4ext::Mutex::Lock()
 {
-    EnterCriticalSection(&cs);
+    EnterCriticalSection(&m_cs);
 }
 
 RED4EXT_INLINE void RED4ext::Mutex::Unlock()
 {
-    LeaveCriticalSection(&cs);
+    LeaveCriticalSection(&m_cs);
 }
 
 RED4EXT_INLINE void RED4ext::Mutex::lock()

--- a/include/RED4ext/Mutex.hpp
+++ b/include/RED4ext/Mutex.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <RED4ext/Common.hpp>
+#include <windows.h>
+
+namespace RED4ext
+{
+struct Mutex
+{
+    CRITICAL_SECTION cs;
+
+    Mutex();
+    Mutex(const Mutex&) = delete;
+    Mutex(Mutex&&) = delete;
+    Mutex& operator=(const Mutex&) = delete;
+    Mutex& operator=(Mutex&&) = delete;
+
+    void Lock();
+    void Unlock();
+
+    // --------------------------------------------
+    // -- support for lock_guard and shared_lock --
+    // --------------------------------------------
+
+    void lock();
+    void unlock();
+};
+RED4EXT_ASSERT_SIZE(Mutex, 40);
+} // namespace RED4ext
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/Mutex-inl.hpp>
+#endif

--- a/include/RED4ext/Mutex.hpp
+++ b/include/RED4ext/Mutex.hpp
@@ -7,8 +7,6 @@ namespace RED4ext
 {
 struct Mutex
 {
-    CRITICAL_SECTION cs;
-
     Mutex();
     Mutex(const Mutex&) = delete;
     Mutex(Mutex&&) = delete;
@@ -19,11 +17,14 @@ struct Mutex
     void Unlock();
 
     // --------------------------------------------
-    // -- support for lock_guard and shared_lock --
+    // -- support for lock_guard --
     // --------------------------------------------
 
     void lock();
     void unlock();
+
+private:
+    CRITICAL_SECTION m_cs;
 };
 RED4EXT_ASSERT_SIZE(Mutex, 40);
 } // namespace RED4ext

--- a/include/RED4ext/RED4ext.hpp
+++ b/include/RED4ext/RED4ext.hpp
@@ -31,6 +31,7 @@
 #include <RED4ext/Scripting/Utils.hpp>
 
 #include <RED4ext/Mutex.hpp>
+#include <RED4ext/SharedMutex.hpp>
 #include <RED4ext/SharedSpinLock.hpp>
 #include <RED4ext/TweakDB.hpp>
 

--- a/include/RED4ext/RED4ext.hpp
+++ b/include/RED4ext/RED4ext.hpp
@@ -30,7 +30,8 @@
 #include <RED4ext/Scripting/Stack.hpp>
 #include <RED4ext/Scripting/Utils.hpp>
 
-#include <RED4ext/SharedMutex.hpp>
+#include <RED4ext/Mutex.hpp>
+#include <RED4ext/SharedSpinLock.hpp>
 #include <RED4ext/TweakDB.hpp>
 
 #include <RED4ext/InstanceType.hpp>

--- a/include/RED4ext/RTTISystem.hpp
+++ b/include/RED4ext/RTTISystem.hpp
@@ -3,12 +3,14 @@
 #include <Windows.h>
 #include <cstdint>
 
-#include <RED4ext/Callback.hpp>
 #include <RED4ext/CName.hpp>
+#include <RED4ext/Callback.hpp>
 #include <RED4ext/Common.hpp>
 #include <RED4ext/DynArray.hpp>
 #include <RED4ext/HashMap.hpp>
+#include <RED4ext/Mutex.hpp>
 #include <RED4ext/RTTITypes.hpp>
+#include <RED4ext/SharedSpinLock.hpp>
 
 namespace RED4ext
 {
@@ -56,10 +58,10 @@ struct IRTTISystem
                                                      // containing the name and the bit.
     virtual void InitializeScriptRuntime() = 0;      // F8 - Called by script loader at the very end
     virtual void RegisterScriptName(CName aNativeName, CName aScriptedName) = 0; // 100
-    virtual CClass* GetClassByScriptName(CName aName) = 0;        // 108
-    virtual CEnum* GetEnumByScriptName(CName aName) = 0;          // 110
-    virtual CName ConvertNativeToScriptName(CName aName) = 0;     // 118
-    virtual CName ConvertScriptToNativeName(CName aName) = 0;     // 120
+    virtual CClass* GetClassByScriptName(CName aName) = 0;                       // 108
+    virtual CEnum* GetEnumByScriptName(CName aName) = 0;                         // 110
+    virtual CName ConvertNativeToScriptName(CName aName) = 0;                    // 118
+    virtual CName ConvertScriptToNativeName(CName aName) = 0;                    // 120
     virtual CString* GetStringConst(uint32_t aIndex) = 0;         // 128 - Used by StringConst opcode (0x10)
     virtual void SetStringTable(DynArray<CString>& aStrings) = 0; // 130 - Called by script loader
 
@@ -88,9 +90,9 @@ struct CRTTISystem : IRTTISystem
     DynArray<CString> strings;                        // 1B0 - Used by StringConst opcode (0x10)
     DynArray<void*> unk1C0;                           // 1C0
     DynArray<void*> unk1D0;                           // 1D0
-    CRITICAL_SECTION unk1E0;                          // 1E0
-    volatile int8_t typesLock;                        // 208
-    CRITICAL_SECTION unk210;                          // 210
+    Mutex unk1E0;                                     // 1E0
+    SharedSpinLock typesLock;                         // 208
+    Mutex rttiRegistratorMutex;                       // 210
 };
 RED4EXT_ASSERT_SIZE(CRTTISystem, 0x238);
 RED4EXT_ASSERT_OFFSET(CRTTISystem, types, 0x10);

--- a/include/RED4ext/RTTITypes.hpp
+++ b/include/RED4ext/RTTITypes.hpp
@@ -53,9 +53,9 @@ struct CBaseRTTIType
     virtual CName GetComputedName() const;                    // 30
     virtual void Construct(ScriptInstance aMemory) const = 0; // 38
     virtual void Destruct(ScriptInstance aMemory) const = 0;  // 40
-    virtual const bool IsEqual(
-        const ScriptInstance aLhs, const ScriptInstance aRhs,
-        uint32_t a3 = 0) = 0; // 48 - Not const because CClass aquire some mutex when this is called and a flag is modified.
+    virtual const bool IsEqual(const ScriptInstance aLhs, const ScriptInstance aRhs,
+                               uint32_t a3 = 0) = 0; // 48 - Not const because CClass aquire some mutex when this is
+                                                     // called and a flag is modified.
     virtual void Assign(ScriptInstance aLhs, const ScriptInstance aRhs) const = 0;                 // 50
     virtual void Move(ScriptInstance aLhs, ScriptInstance aRhs) const;                             // 58
     virtual bool Unserialize(BaseStream* aStream, ScriptInstance aInstance, int64_t a3) const = 0; // 60
@@ -225,7 +225,7 @@ struct CClass : CBaseRTTIType
     int8_t listening[256];                       // 1C0 - Bitmask of event types that this class listens to
     int16_t eventTypeId;                         // 2C0 - Assigned to event classes only
     int32_t unk2C4;                              // 2C4
-    SharedMutex unk2C8;                          // 2C8
+    SharedSpinLock unk2C8;                       // 2C8
     uint8_t unk2C9;                              // 2C9
 };
 RED4EXT_ASSERT_SIZE(CClass, 0x2D0);
@@ -594,62 +594,141 @@ RED4EXT_ASSERT_SIZE(CRTTIMultiChannelCurveType, 0x48);
 RED4EXT_ASSERT_OFFSET(CRTTIMultiChannelCurveType, name, 0x10);
 RED4EXT_ASSERT_OFFSET(CRTTIMultiChannelCurveType, curveType, 0x18);
 
-struct [[deprecated("Use 'CBaseRTTIType' instead.")]] IRTTIType : CBaseRTTIType{};
-struct [[deprecated("Use 'CBaseRTTIType' instead.")]] CRTTIBaseType : CBaseRTTIType{};
-struct [[deprecated("Use 'CBaseRTTIType' instead.")]] CRTTIType : CBaseRTTIType{};
+struct [[deprecated("Use 'CBaseRTTIType' instead.")]] IRTTIType : CBaseRTTIType
+{
+};
+struct [[deprecated("Use 'CBaseRTTIType' instead.")]] CRTTIBaseType : CBaseRTTIType
+{
+};
+struct [[deprecated("Use 'CBaseRTTIType' instead.")]] CRTTIType : CBaseRTTIType
+{
+};
 
-struct [[deprecated("Use 'CFundamentalRTTITypeBool' instead.")]] BoolType : CFundamentalRTTITypeBool{};
-struct [[deprecated("Use 'CFundamentalRTTITypeInt8' instead.")]] Int8Type : CFundamentalRTTITypeInt8{};
-struct [[deprecated("Use 'CFundamentalRTTITypeUint8' instead.")]] Uint8Type : CFundamentalRTTITypeUint8{};
-struct [[deprecated("Use 'CFundamentalRTTITypeInt16' instead.")]] Int16Type : CFundamentalRTTITypeInt16{};
-struct [[deprecated("Use 'CFundamentalRTTITypeUint16' instead.")]] Uint16Type : CFundamentalRTTITypeUint16{};
-struct [[deprecated("Use 'CFundamentalRTTITypeInt32' instead.")]] Int32Type : CFundamentalRTTITypeInt32{};
-struct [[deprecated("Use 'CFundamentalRTTITypeUint32' instead.")]] Uint32Type : CFundamentalRTTITypeUint32{};
-struct [[deprecated("Use 'CFundamentalRTTITypeInt64' instead.")]] Int64Type : CFundamentalRTTITypeInt64{};
-struct [[deprecated("Use 'CFundamentalRTTITypeUint64' instead.")]] Uint64Type : CFundamentalRTTITypeUint64{};
-struct [[deprecated("Use 'CFundamentalRTTITypeFloat' instead.")]] FloatType : CFundamentalRTTITypeFloat{};
-struct [[deprecated("Use 'CFundamentalRTTITypeDouble' instead.")]] DoubleType : CFundamentalRTTITypeDouble{};
+struct [[deprecated("Use 'CFundamentalRTTITypeBool' instead.")]] BoolType : CFundamentalRTTITypeBool
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeInt8' instead.")]] Int8Type : CFundamentalRTTITypeInt8
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeUint8' instead.")]] Uint8Type : CFundamentalRTTITypeUint8
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeInt16' instead.")]] Int16Type : CFundamentalRTTITypeInt16
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeUint16' instead.")]] Uint16Type : CFundamentalRTTITypeUint16
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeInt32' instead.")]] Int32Type : CFundamentalRTTITypeInt32
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeUint32' instead.")]] Uint32Type : CFundamentalRTTITypeUint32
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeInt64' instead.")]] Int64Type : CFundamentalRTTITypeInt64
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeUint64' instead.")]] Uint64Type : CFundamentalRTTITypeUint64
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeFloat' instead.")]] FloatType : CFundamentalRTTITypeFloat
+{
+};
+struct [[deprecated("Use 'CFundamentalRTTITypeDouble' instead.")]] DoubleType : CFundamentalRTTITypeDouble
+{
+};
 
-struct [[deprecated("Use 'CSimpleRTTITypeCName' instead.")]] CNameType : CSimpleRTTITypeCName{};
-struct [[deprecated("Use 'CSimpleRTTITypeString' instead.")]] StringType : CSimpleRTTITypeString{};
+struct [[deprecated("Use 'CSimpleRTTITypeCName' instead.")]] CNameType : CSimpleRTTITypeCName
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeString' instead.")]] StringType : CSimpleRTTITypeString
+{
+};
 struct [[deprecated("Use 'CSimpleRTTITypeLocalizationString' instead.")]] LocalizationStringType
-    : CSimpleRTTITypeLocalizationString{};
-struct [[deprecated("Use 'CSimpleRTTITypeTweakDBID' instead.")]] TweakDBIDType : CSimpleRTTITypeTweakDBID{};
-struct [[deprecated("Use 'CSimpleRTTITypeDataBuffer' instead.")]] DataBufferType : CSimpleRTTITypeDataBuffer{};
+    : CSimpleRTTITypeLocalizationString
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeTweakDBID' instead.")]] TweakDBIDType : CSimpleRTTITypeTweakDBID
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeDataBuffer' instead.")]] DataBufferType : CSimpleRTTITypeDataBuffer
+{
+};
 struct [[deprecated("Use 'CSimpleRTTITypeSharedDataBuffer' instead.")]] SharedDataBufferType
-    : CSimpleRTTITypeSharedDataBuffer{};
+    : CSimpleRTTITypeSharedDataBuffer
+{
+};
 struct [[deprecated(
     "Use 'CSimpleRTTITypeSerializationDeferredDataBuffer' instead.")]] serializationDeferredDataBufferType
-    : CSimpleRTTITypeSerializationDeferredDataBuffer{};
-struct [[deprecated("Use 'CSimpleRTTITypeVariant' instead.")]] VariantType : CSimpleRTTITypeVariant{};
-struct [[deprecated("Use 'CSimpleRTTITypeCDateTime' instead.")]] CDateTimeType : CSimpleRTTITypeCDateTime{};
-struct [[deprecated("Use 'CSimpleRTTITypeCGUID' instead.")]] CGUIDType : CSimpleRTTITypeCGUID{};
-struct [[deprecated("Use 'CSimpleRTTITypeCRUID' instead.")]] CRUIDType : CSimpleRTTITypeCRUID{};
-struct [[deprecated("Use 'CSimpleRTTITypeCRUIDRef' instead.")]] CRUIDRefType : CSimpleRTTITypeCRUIDRef{};
-struct [[deprecated("Use 'CSimpleRTTITypeEditorObjectID' instead.")]] EditorObjectIDType
-    : CSimpleRTTITypeEditorObjectID{};
+    : CSimpleRTTITypeSerializationDeferredDataBuffer
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeVariant' instead.")]] VariantType : CSimpleRTTITypeVariant
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeCDateTime' instead.")]] CDateTimeType : CSimpleRTTITypeCDateTime
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeCGUID' instead.")]] CGUIDType : CSimpleRTTITypeCGUID
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeCRUID' instead.")]] CRUIDType : CSimpleRTTITypeCRUID
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeCRUIDRef' instead.")]] CRUIDRefType : CSimpleRTTITypeCRUIDRef
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeEditorObjectID' instead.")]] EditorObjectIDType : CSimpleRTTITypeEditorObjectID
+{
+};
 struct [[deprecated("Use 'CSimpleRTTITypeGamedataLocKeyWrapper' instead.")]] gamedataLocKeyWrapperType
-    : CSimpleRTTITypeGamedataLocKeyWrapper{};
+    : CSimpleRTTITypeGamedataLocKeyWrapper
+{
+};
 struct [[deprecated("Use 'CSimpleRTTITypeMessageResourcePath' instead.")]] MessageResourcePathType
-    : CSimpleRTTITypeMessageResourcePath{};
-struct [[deprecated("Use 'CSimpleRTTITypeNodeRef' instead.")]] NodeRefType : CSimpleRTTITypeNodeRef{};
+    : CSimpleRTTITypeMessageResourcePath
+{
+};
+struct [[deprecated("Use 'CSimpleRTTITypeNodeRef' instead.")]] NodeRefType : CSimpleRTTITypeNodeRef
+{
+};
 struct [[deprecated("Use 'CSimpleRTTITypeRuntimeEntityRef' instead.")]] RuntimeEntityRefType
-    : CSimpleRTTITypeRuntimeEntityRef{};
+    : CSimpleRTTITypeRuntimeEntityRef
+{
+};
 
-struct [[deprecated("Use 'CRTTIBaseArrayType' instead.")]] CArrayBase : CRTTIBaseArrayType{};
-struct [[deprecated("Use 'CRTTIArrayType' instead.")]] CArray : CRTTIArrayType{};
-struct [[deprecated("Use 'CRTTIStaticArrayType' instead.")]] CStaticArray : CRTTIStaticArrayType{};
-struct [[deprecated("Use 'CRTTINativeArrayType' instead.")]] CNativeArray : CRTTINativeArrayType{};
+struct [[deprecated("Use 'CRTTIBaseArrayType' instead.")]] CArrayBase : CRTTIBaseArrayType
+{
+};
+struct [[deprecated("Use 'CRTTIArrayType' instead.")]] CArray : CRTTIArrayType
+{
+};
+struct [[deprecated("Use 'CRTTIStaticArrayType' instead.")]] CStaticArray : CRTTIStaticArrayType
+{
+};
+struct [[deprecated("Use 'CRTTINativeArrayType' instead.")]] CNativeArray : CRTTINativeArrayType
+{
+};
 
-struct [[deprecated("Use 'CRTTIHandleType' instead.")]] CHandle : CRTTIHandleType{};
-struct [[deprecated("Use 'CRTTIWeakHandleType' instead.")]] CWeakHandle : CRTTIWeakHandleType{};
-struct [[deprecated("Use 'CRTTIResourceReferenceType' instead.")]] CResourceReference : CRTTIResourceReferenceType{};
+struct [[deprecated("Use 'CRTTIHandleType' instead.")]] CHandle : CRTTIHandleType
+{
+};
+struct [[deprecated("Use 'CRTTIWeakHandleType' instead.")]] CWeakHandle : CRTTIWeakHandleType
+{
+};
+struct [[deprecated("Use 'CRTTIResourceReferenceType' instead.")]] CResourceReference : CRTTIResourceReferenceType
+{
+};
 
 struct [[deprecated("Use 'CRTTIResourceAsyncReferenceType' instead.")]] CResourceAsyncReference
-    : CRTTIResourceAsyncReferenceType{};
+    : CRTTIResourceAsyncReferenceType
+{
+};
 
 struct [[deprecated("Use 'CRTTILegacySingleChannelCurveType' instead.")]] CLegacySingleChannelCurve
-    : CRTTILegacySingleChannelCurveType{};
+    : CRTTILegacySingleChannelCurveType
+{
+};
 } // namespace RED4ext
 
 #ifdef RED4EXT_HEADER_ONLY

--- a/include/RED4ext/ResourceLoader.hpp
+++ b/include/RED4ext/ResourceLoader.hpp
@@ -2,9 +2,9 @@
 
 #include <type_traits>
 
-#include <RED4ext/Detail/AddressHashes.hpp>
 #include <RED4ext/Callback.hpp>
 #include <RED4ext/Common.hpp>
+#include <RED4ext/Detail/AddressHashes.hpp>
 #include <RED4ext/DynArray.hpp>
 #include <RED4ext/HashMap.hpp>
 #include <RED4ext/JobQueue.hpp>
@@ -99,7 +99,7 @@ struct ResourceToken
 
     WeakPtr<ResourceToken<T>> self;                    // 00
     DynArray<SharedPtr<ResourceToken<>>> dependencies; // 10
-    SharedMutex lock;                                  // 20
+    SharedSpinLock lock;                               // 20
     Handle<T> resource;                                // 28
     void* unk38;                                       // 38 - SharedPtr<Unk38>.instance
     void* unk40;                                       // 40 - SharedPtr<Unk38>.refCount
@@ -139,7 +139,7 @@ struct ResourceLoader
         using FindToken_t = uintptr_t (*)(ResourceLoader*, SharedPtr<ResourceToken<T>>*, ResourcePath);
         static UniversalRelocFunc<FindToken_t> func(Detail::AddressHashes::ResourceLoader_FindTokenFast);
 
-        std::shared_lock<SharedMutex> _(tokenLock);
+        std::shared_lock<SharedSpinLock> _(tokenLock);
 
         SharedPtr<ResourceToken<T>> token;
         func(this, &token, aPath);
@@ -149,7 +149,7 @@ struct ResourceLoader
 
     HashMap<ResourcePath, WeakPtr<ResourceToken<>>> tokens; // 00
     DynArray<SharedPtr<ResourceToken<>>> failed;            // 30
-    SharedMutex tokenLock;                                  // 40
+    SharedSpinLock tokenLock;                               // 40
     uintptr_t unk48;                                        // 48
     uintptr_t unk50;                                        // 50
     uintptr_t unk58;                                        // 58

--- a/include/RED4ext/Scripting/Natives/inkHUDLayer.hpp
+++ b/include/RED4ext/Scripting/Natives/inkHUDLayer.hpp
@@ -21,7 +21,7 @@ struct __declspec(align(0x10)) HUDLayer : ink::FullScreenLayer
     Ref<HudEntriesResource> resource;      // 170
     HUDLayerDefinition* definition;        // 188
     JobHandle spawningJob;                 // 190
-    SharedMutex spawningLock;              // 198
+    SharedSpinLock spawningLock;           // 198
     uint8_t unk199[0x200 - 0x199];         // 199
 };
 RED4EXT_ASSERT_SIZE(HUDLayer, 0x200);

--- a/include/RED4ext/Scripting/Natives/inkMultiChildren.hpp
+++ b/include/RED4ext/Scripting/Natives/inkMultiChildren.hpp
@@ -14,7 +14,7 @@ struct MultiChildren : Children
     static constexpr const char* NAME = "inkMultiChildren";
     static constexpr const char* ALIAS = NAME;
 
-    SharedMutex lock;                  // 30
+    SharedSpinLock lock;               // 30
     DynArray<Handle<Widget>> children; // 38
 };
 RED4EXT_ASSERT_SIZE(MultiChildren, 0x48);

--- a/include/RED4ext/Scripting/Natives/inkWidget.hpp
+++ b/include/RED4ext/Scripting/Natives/inkWidget.hpp
@@ -47,10 +47,10 @@ struct Widget : IScriptable
     uint8_t unk1B0[0x1E0 - 0x1B0];                                // 1B0
     HDRColor tintColor;                                           // 1E0
     float opacity;                                                // 1F0
-    SharedMutex parentLock;                                       // 1F4
-    SharedMutex unk1F5;                                           // 1F5
-    SharedMutex unk1F6;                                           // 1F6
-    SharedMutex userDataLock;                                     // 1F7
+    SharedSpinLock parentLock;                                    // 1F4
+    SharedSpinLock unk1F5;                                        // 1F5
+    SharedSpinLock unk1F6;                                        // 1F6
+    SharedSpinLock userDataLock;                                  // 1F7
     bool visible;                                                 // 1F8
     bool canSupportFocus;                                         // 1F9
     bool fitToContent;                                            // 1FA

--- a/include/RED4ext/Scripting/Natives/inkWorldLayer.hpp
+++ b/include/RED4ext/Scripting/Natives/inkWorldLayer.hpp
@@ -13,9 +13,9 @@ struct WorldLayer : ink::Layer
     static constexpr const char* NAME = "inkWorldLayer";
     static constexpr const char* ALIAS = NAME;
 
-    SharedMutex unk150;                                      // 150
+    SharedSpinLock unk150;                                   // 150
     DynArray<void*> unk158;                                  // 158
-    SharedMutex unk168;                                      // 168
+    SharedSpinLock unk168;                                   // 168
     DynArray<SharedPtr<IWidgetComponentWrapper>> components; // 170
     uint8_t unk180[0x1B8 - 0x180];                           // 180
 };

--- a/include/RED4ext/SharedMutex.hpp
+++ b/include/RED4ext/SharedMutex.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace RED4ext
+{
+using SharedMutex [[deprecated("Use SharedSpinLock instead")]] = SharedSpinLock;
+} // namespace RED4ext

--- a/include/RED4ext/SharedSpinLock-inl.hpp
+++ b/include/RED4ext/SharedSpinLock-inl.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifdef RED4EXT_STATIC_LIB
-#include <RED4ext/SharedMutex.hpp>
+#include <RED4ext/SharedSpinLock.hpp>
 #endif
 
 #include <cstdint>
@@ -9,17 +9,17 @@
 
 #include <Windows.h>
 
-RED4EXT_INLINE RED4ext::SharedMutex::SharedMutex()
+RED4EXT_INLINE RED4ext::SharedSpinLock::SharedSpinLock()
     : state(0)
 {
 }
 
-RED4EXT_INLINE bool RED4ext::SharedMutex::TryLock()
+RED4EXT_INLINE bool RED4ext::SharedSpinLock::TryLock()
 {
     return _InterlockedCompareExchange8(&state, -1, 0) == 0;
 }
 
-RED4EXT_INLINE void RED4ext::SharedMutex::Lock()
+RED4EXT_INLINE void RED4ext::SharedSpinLock::Lock()
 {
     int32_t loopCount = 0;
     while (true)
@@ -35,12 +35,12 @@ RED4EXT_INLINE void RED4ext::SharedMutex::Lock()
     }
 }
 
-RED4EXT_INLINE void RED4ext::SharedMutex::Unlock()
+RED4EXT_INLINE void RED4ext::SharedSpinLock::Unlock()
 {
     InterlockedExchange8(&state, 0);
 }
 
-RED4EXT_INLINE bool RED4ext::SharedMutex::TryLockShared()
+RED4EXT_INLINE bool RED4ext::SharedSpinLock::TryLockShared()
 {
     char currentState = state;
     if (currentState != -1)
@@ -50,7 +50,7 @@ RED4EXT_INLINE bool RED4ext::SharedMutex::TryLockShared()
     return false;
 }
 
-RED4EXT_INLINE void RED4ext::SharedMutex::LockShared()
+RED4EXT_INLINE void RED4ext::SharedSpinLock::LockShared()
 {
     int32_t loopCount = 0;
     while (true)
@@ -66,7 +66,7 @@ RED4EXT_INLINE void RED4ext::SharedMutex::LockShared()
     }
 }
 
-RED4EXT_INLINE void RED4ext::SharedMutex::UnlockShared()
+RED4EXT_INLINE void RED4ext::SharedSpinLock::UnlockShared()
 {
     _InterlockedExchangeAdd8(&state, -1);
 }
@@ -75,32 +75,32 @@ RED4EXT_INLINE void RED4ext::SharedMutex::UnlockShared()
 // -- support for lock_guard and shared_lock --
 // --------------------------------------------
 
-RED4EXT_INLINE bool RED4ext::SharedMutex::try_lock()
+RED4EXT_INLINE bool RED4ext::SharedSpinLock::try_lock()
 {
     return TryLock();
 }
 
-RED4EXT_INLINE void RED4ext::SharedMutex::lock()
+RED4EXT_INLINE void RED4ext::SharedSpinLock::lock()
 {
     Lock();
 }
 
-RED4EXT_INLINE void RED4ext::SharedMutex::unlock()
+RED4EXT_INLINE void RED4ext::SharedSpinLock::unlock()
 {
     Unlock();
 }
 
-RED4EXT_INLINE bool RED4ext::SharedMutex::try_lock_shared()
+RED4EXT_INLINE bool RED4ext::SharedSpinLock::try_lock_shared()
 {
     return TryLockShared();
 }
 
-RED4EXT_INLINE void RED4ext::SharedMutex::lock_shared()
+RED4EXT_INLINE void RED4ext::SharedSpinLock::lock_shared()
 {
     LockShared();
 }
 
-RED4EXT_INLINE void RED4ext::SharedMutex::unlock_shared()
+RED4EXT_INLINE void RED4ext::SharedSpinLock::unlock_shared()
 {
     UnlockShared();
 }

--- a/include/RED4ext/SharedSpinLock.hpp
+++ b/include/RED4ext/SharedSpinLock.hpp
@@ -4,18 +4,18 @@
 
 namespace RED4ext
 {
-struct SharedMutex
+struct SharedSpinLock
 {
     // -1 : write
     // 0 : free
     // + : read
     volatile char state;
 
-    SharedMutex();
-    SharedMutex(const SharedMutex&) = delete;
-    SharedMutex(SharedMutex&&) = delete;
-    SharedMutex& operator=(const SharedMutex&) = delete;
-    SharedMutex& operator=(SharedMutex&&) = delete;
+    SharedSpinLock();
+    SharedSpinLock(const SharedSpinLock&) = delete;
+    SharedSpinLock(SharedSpinLock&&) = delete;
+    SharedSpinLock& operator=(const SharedSpinLock&) = delete;
+    SharedSpinLock& operator=(SharedSpinLock&&) = delete;
 
     bool TryLock();
     void Lock();
@@ -37,9 +37,9 @@ struct SharedMutex
     void lock_shared();
     void unlock_shared();
 };
-RED4EXT_ASSERT_SIZE(SharedMutex, 1);
+RED4EXT_ASSERT_SIZE(SharedSpinLock, 1);
 } // namespace RED4ext
 
 #ifdef RED4EXT_HEADER_ONLY
-#include <RED4ext/SharedMutex-inl.hpp>
+#include <RED4ext/SharedSpinLock-inl.hpp>
 #endif

--- a/include/RED4ext/TweakDB-inl.hpp
+++ b/include/RED4ext/TweakDB-inl.hpp
@@ -28,7 +28,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::TryGetRecord(TweakDBID aDBID, Handle<IScri
 {
     if (!aDBID.IsValid())
         return false;
-    std::shared_lock<SharedMutex> _(mutex01);
+    std::shared_lock<SharedSpinLock> _(mutex01);
 
     auto* record = recordsByID.Get(aDBID);
     if (record == nullptr)
@@ -49,7 +49,7 @@ RED4EXT_INLINE RED4ext::DynArray<RED4ext::Handle<RED4ext::IScriptable>> RED4ext:
 RED4EXT_INLINE bool RED4ext::TweakDB::TryGetRecordsByType(CBaseRTTIType* aType,
                                                           DynArray<Handle<IScriptable>>& aRecordsArray)
 {
-    std::shared_lock<SharedMutex> _(mutex01);
+    std::shared_lock<SharedSpinLock> _(mutex01);
 
     auto* records = recordsByType.Get(aType);
     if (records == nullptr)
@@ -66,7 +66,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::AddQuery(TweakDBID aDBID, const DynArray<T
         return false;
     }
 
-    std::lock_guard<SharedMutex> _(mutex01);
+    std::lock_guard<SharedSpinLock> _(mutex01);
     return queries.Insert(aDBID, aArray).second;
 }
 
@@ -77,7 +77,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::ReplaceQuery(TweakDBID aDBID, const DynArr
         return false;
     }
 
-    std::lock_guard<SharedMutex> _(mutex01);
+    std::lock_guard<SharedSpinLock> _(mutex01);
     return queries.InsertOrAssign(aDBID, aArray).second;
 }
 
@@ -92,7 +92,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::TryQuery(TweakDBID aDBID, DynArray<TweakDB
 {
     if (!aDBID.IsValid())
         return false;
-    std::shared_lock<SharedMutex> _(mutex01);
+    std::shared_lock<SharedSpinLock> _(mutex01);
 
     const auto* recordArray = queries.Get(aDBID);
     if (recordArray == nullptr)
@@ -109,7 +109,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::HasQuery(TweakDBID aDBID)
         return false;
     }
 
-    std::shared_lock<SharedMutex> _(mutex01);
+    std::shared_lock<SharedSpinLock> _(mutex01);
     const auto queriesArray = queries.Get(aDBID);
     return queriesArray != nullptr;
 }
@@ -121,7 +121,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::AddGroupTag(TweakDBID aDBID, GroupTag aGro
         return false;
     }
 
-    std::lock_guard<SharedMutex> _(mutex01);
+    std::lock_guard<SharedSpinLock> _(mutex01);
     return groups.Insert(aDBID, aGroup).second;
 }
 
@@ -132,7 +132,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::ReplaceGroupTag(TweakDBID aDBID, GroupTag 
         return false;
     }
 
-    std::lock_guard<SharedMutex> _(mutex01);
+    std::lock_guard<SharedSpinLock> _(mutex01);
     return groups.InsertOrAssign(aDBID, aGroup).second;
 }
 
@@ -143,7 +143,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::HasGroupTag(TweakDBID aDBID)
         return false;
     }
 
-    std::shared_lock<SharedMutex> _(mutex01);
+    std::shared_lock<SharedSpinLock> _(mutex01);
     const auto group = groups.Get(aDBID);
     return group != nullptr;
 }
@@ -237,7 +237,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::CreateRecord(TweakDBID aDBID, CBaseRTTITyp
 {
     Handle<IScriptable> record;
     {
-        std::shared_lock<SharedMutex> _(mutex01);
+        std::shared_lock<SharedSpinLock> _(mutex01);
 
         const auto* records = recordsByType.Get(aType);
         if (records == nullptr || records->size == 0)
@@ -273,7 +273,7 @@ RED4EXT_INLINE bool RED4ext::TweakDB::RemoveRecord(TweakDBID aDBID)
     if (!record)
         return false;
 
-    std::lock_guard<SharedMutex> _(mutex01);
+    std::lock_guard<SharedSpinLock> _(mutex01);
     if (recordsByID.Remove(aDBID))
     {
         auto* records = recordsByType.Get(record->GetNativeType());
@@ -285,21 +285,21 @@ RED4EXT_INLINE bool RED4ext::TweakDB::RemoveRecord(TweakDBID aDBID)
 
 RED4EXT_INLINE bool RED4ext::TweakDB::AddFlat(TweakDBID aDBID)
 {
-    std::lock_guard<SharedMutex> _(mutex00);
+    std::lock_guard<SharedSpinLock> _(mutex00);
 
     return flats.Insert(aDBID).second;
 }
 
 RED4EXT_INLINE bool RED4ext::TweakDB::AddFlats(const SortedUniqueArray<TweakDBID>& aDBIDs)
 {
-    std::lock_guard<SharedMutex> _(mutex00);
+    std::lock_guard<SharedSpinLock> _(mutex00);
 
     return flats.Insert(aDBIDs) > 0;
 }
 
 RED4EXT_INLINE bool RED4ext::TweakDB::RemoveFlat(TweakDBID aDBID)
 {
-    std::lock_guard<SharedMutex> _(mutex00);
+    std::lock_guard<SharedSpinLock> _(mutex00);
 
     return flats.Remove(aDBID);
 }
@@ -308,7 +308,7 @@ RED4EXT_INLINE RED4ext::TweakDB::FlatValue* RED4ext::TweakDB::GetFlatValue(Tweak
 {
     if (!aDBID.IsValid())
         return nullptr;
-    std::shared_lock<SharedMutex> _(mutex00);
+    std::shared_lock<SharedSpinLock> _(mutex00);
 
     if (!aDBID.HasTDBOffset())
     {
@@ -330,7 +330,7 @@ RED4EXT_INLINE int32_t RED4ext::TweakDB::CreateFlatValue(const CStackType& aStac
     uintptr_t flatDataBufferEnd_Aligned = RED4ext::AlignUp(flatDataBufferEnd, flatAlignment);
 
     {
-        std::lock_guard<SharedMutex> _(mutex00);
+        std::lock_guard<SharedSpinLock> _(mutex00);
 
         if (flatDataBufferEnd_Aligned + flatValueSize > flatDataBuffer + flatDataBufferCapacity)
         {
@@ -443,7 +443,7 @@ RED4EXT_INLINE void RED4ext::TweakDB::SetFlatDataBuffer(void* aBuffer, uint32_t 
 
 RED4EXT_INLINE const RED4ext::TweakDB::FlatValue* RED4ext::TweakDB::GetDefaultFlatValue(CName aTypeName)
 {
-    std::shared_lock<SharedMutex> _(mutex00);
+    std::shared_lock<SharedSpinLock> _(mutex00);
 
     FlatValue** flatValue = defaultValues.Get(aTypeName);
     return flatValue ? *flatValue : nullptr;

--- a/include/RED4ext/TweakDB.hpp
+++ b/include/RED4ext/TweakDB.hpp
@@ -19,7 +19,7 @@
 #include <RED4ext/Scripting/Natives/Generated/Vector3.hpp>
 #include <RED4ext/Scripting/Natives/gamedataTweakDBRecord.hpp>
 #include <RED4ext/Scripting/Stack.hpp>
-#include <RED4ext/SharedMutex.hpp>
+#include <RED4ext/SharedSpinLock.hpp>
 #include <RED4ext/SortedArray.hpp>
 
 namespace RED4ext
@@ -145,8 +145,8 @@ struct TweakDB
     uint64_t unk08;                 // 08
     void* unkF0;                    // F0
     void* unkF8;                    // F8
-    SharedMutex mutex00;            // 20 - used with flats, flatDataBuffer* and defaultValues
-    SharedMutex mutex01;            // 21 - used with recordsByID, recordsByType, queries and groups
+    SharedSpinLock mutex00;         // 20 - used with flats, flatDataBuffer* and defaultValues
+    SharedSpinLock mutex01;         // 21 - used with recordsByID, recordsByType, queries and groups
     void* unk28;                    // 28 - class - 344 bytes - has DynArray<GroupTagCName> and DynArray<TagVal-1byte>
     void* unk30;                    // 30 - class - 248 bytes
     bool unk38;                     // 38
@@ -174,7 +174,7 @@ struct TweakDB
     template<typename T>
     bool TryGetValue(TweakDBID aDBID, T& aValue)
     {
-        std::shared_lock<SharedMutex> _(mutex00);
+        std::shared_lock<SharedSpinLock> _(mutex00);
 
         auto* flatValue = GetFlatValue(aDBID);
         if (flatValue == nullptr)

--- a/src/Mutex.cpp
+++ b/src/Mutex.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/Mutex-inl.hpp>

--- a/src/SharedSpinLock.cpp
+++ b/src/SharedSpinLock.cpp
@@ -2,4 +2,4 @@
 #error Please define 'RED4EXT_STATIC_LIB' to compile this file.
 #endif
 
-#include <RED4ext/SharedMutex-inl.hpp>
+#include <RED4ext/SharedSpinLock-inl.hpp>


### PR DESCRIPTION
I was looking into the RTTI and there appear to be 4 types of locks:
- spin lock (currently named SpinLock in the SDK)
- shared spin lock (currently named SharedMutex in the SDK)
- mutex (uses critical section, does not exist in the SDK)
- shared mutex (uses srwlock, does not exist in the SDK)

In this PR I do a little bit of cleanup:
- rename `SharedMutex` to `SharedSpinLock`, because that's the more appopriate name, in c++ a shared mutex corresponds to a srwlock on Windows, not a spin lock
- introduce `Mutex`
- update the RTTI system to make use of `Mutex` and `SharedSpinLock`

I didn't add the rwlock because I don't think it's needed anywhere in the SDK right now.