### PR TITLE
Various changes

### DIFF
--- a/include/RED4ext/Buffer-inl.hpp
+++ b/include/RED4ext/Buffer-inl.hpp
@@ -28,6 +28,15 @@ RED4EXT_INLINE RED4ext::RawBuffer::~RawBuffer()
     }
 }
 
+RED4EXT_INLINE void RED4ext::RawBuffer::Resize(uint32_t aSize)
+{
+    if (data && allocator[0])
+    {
+        data = reinterpret_cast<RawBufferAllocator*>(&allocator)->ReallocAligned(data, aSize, alignment);
+        size = aSize;
+    }
+}
+
 RED4EXT_INLINE RED4ext::SharedPtr<RED4ext::DeferredDataBufferToken> RED4ext::DeferredDataBuffer::LoadAsync()
 {
     using LoadBufferAsync_t = JobHandle* (*)(DeferredDataBuffer*, JobHandle*, int64_t);

--- a/include/RED4ext/Buffer.hpp
+++ b/include/RED4ext/Buffer.hpp
@@ -11,9 +11,9 @@ namespace RED4ext
 {
 struct RawBufferAllocator
 {
-    virtual void sub_00() = 0;                     // 08
-    virtual void Free(void* aData) = 0;            // 08
-    virtual Memory::IAllocator GetAllocator() = 0; // 10
+    virtual void* ReallocAligned(void* aData, uint32_t aSize, uint32_t aAlignment) = 0; // 00
+    virtual void Free(void* aData) = 0;                                                 // 08
+    virtual Memory::IAllocator GetAllocator() = 0;                                      // 10
 
     void* unk08;
 };
@@ -28,6 +28,8 @@ struct RawBuffer
     RawBuffer(const RawBuffer&) = delete;
     RawBuffer(RawBuffer&&) = default;
     ~RawBuffer();
+
+    void Resize(uint32_t aSize);
 
     void* data;            // 00
     uint32_t size;         // 08

--- a/include/RED4ext/CName.hpp
+++ b/include/RED4ext/CName.hpp
@@ -15,12 +15,20 @@ struct CName
     {
     }
 
-    constexpr CName(const char* aName) noexcept
+    constexpr CName(const char* aName, size_t aLength = 0) noexcept
         : hash(0)
     {
         constexpr CName None = FNV1a64("None");
 
-        hash = FNV1a64(aName);
+        if (aLength <= 0)
+        {
+            hash = FNV1a64(aName);
+        }
+        else
+        {
+            hash = FNV1a64(reinterpret_cast<const uint8_t*>(aName), aLength);
+        }
+
         if (hash == None)
         {
             hash = 0;

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -80,10 +80,19 @@ struct TweakDBID
         name.tdbOffsetBE[2] = 0;
     }
 
-    constexpr TweakDBID(const char* aName) noexcept
+    constexpr TweakDBID(const char* aName, size_t aLength = 0) noexcept
     {
-        name.hash = CRC32(aName, 0);
-        name.length = static_cast<uint8_t>(std::char_traits<char>::length(aName));
+        if (aLength <= 0)
+        {
+            name.hash = CRC32(aName, 0);
+            name.length = static_cast<uint8_t>(std::char_traits<char>::length(aName));
+        }
+        else
+        {
+            name.hash = CRC32(reinterpret_cast<const uint8_t*>(aName), aLength, 0);
+            name.length = static_cast<uint8_t>(aLength);
+        }
+
         name.tdbOffsetBE[0] = 0;
         name.tdbOffsetBE[1] = 0;
         name.tdbOffsetBE[2] = 0;


### PR DESCRIPTION
- Added raw buffer resize method
- Added alternative ctors for `CName`, `TweakDBID`, `ResourcePath`, that accept non-null-terminated strings