### PR TITLE
String view class + launch param access

### DIFF
--- a/include/RED4ext/CommandLine-inl.hpp
+++ b/include/RED4ext/CommandLine-inl.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/CommandLine.hpp>
+#endif
+
+#include <RED4ext/Detail/AddressHashes.hpp>
+#include <RED4ext/Relocation.hpp>
+#include <RED4ext/StringView.hpp>
+
+RED4EXT_INLINE RED4ext::CommandLine* RED4ext::CommandLine::Get() noexcept
+{
+    // NOTE: GetAddr is actually necessary here
+
+    static CommandLine* ptr{
+        RED4ext::UniversalRelocPtr<RED4ext::CommandLine>(RED4ext::Detail::AddressHashes::CommandLine).GetAddr()};
+    return ptr;
+}
+
+RED4EXT_INLINE bool RED4ext::CommandLine::HasLaunchParameter(RED4ext::StringView aParam) noexcept
+{
+    using func_t =
+        bool (*)(RED4ext::CommandLine* aThis, StringView aParam, std::uint32_t* aOptionIndex, std::uint64_t** aUnk2);
+
+    static func_t func{
+        RED4ext::UniversalRelocFunc<func_t>(RED4ext::Detail::AddressHashes::CommandLine_HasLaunchParameter)};
+
+    std::uint32_t optionIndex{};
+    std::uint64_t* unkPtr{};
+
+    return func(this, aParam, &optionIndex, &unkPtr);
+}

--- a/include/RED4ext/CommandLine.hpp
+++ b/include/RED4ext/CommandLine.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <RED4ext/Common.hpp>
+
+namespace RED4ext
+{
+
+struct StringView;
+
+class CommandLine
+{
+    static CommandLine* Get() noexcept;
+    bool HasLaunchParameter(StringView aParam) noexcept;
+};
+} // namespace RED4ext
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/CommandLine-inl.hpp>
+#endif

--- a/include/RED4ext/Detail/AddressHashes.hpp
+++ b/include/RED4ext/Detail/AddressHashes.hpp
@@ -219,5 +219,10 @@ constexpr std::uint32_t UpdateRegistrar_RegisterBucketUpdate = 0x192F4EA2;
 constexpr std::uint32_t DeferredDataBuffer_LoadAsync = 4125893577;
 constexpr std::uint32_t DeferredDataBuffer_LoadRefAsync = 1459046115;
 #pragma endregion
+
+#pragma region CommandLine
+constexpr std::uint32_t CommandLine = 677908004;
+constexpr std::uint32_t CommandLine_HasLaunchParameter = 2449555025;
+#pragma endregion
 }
 // clang-format on

--- a/include/RED4ext/StringView-inl.hpp
+++ b/include/RED4ext/StringView-inl.hpp
@@ -1,0 +1,106 @@
+#pragma once
+
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/StringView.hpp>
+#endif
+
+#include <RED4ext/CString.hpp>
+
+RED4EXT_INLINE constexpr RED4ext::StringView::StringView() noexcept
+    : ptr(nullptr)
+    , len(0u)
+{
+}
+
+RED4EXT_INLINE constexpr RED4ext::StringView::StringView(const char* aStr) noexcept
+    : ptr(aStr)
+    , len(static_cast<std::uint32_t>(std::char_traits<char>::length(aStr)))
+{
+}
+
+RED4EXT_INLINE constexpr RED4ext::StringView::StringView(std::string_view aView) noexcept
+    : ptr(aView.data())
+    , len(static_cast<std::uint32_t>(aView.length()))
+{
+}
+
+RED4EXT_INLINE RED4ext::StringView::StringView(const RED4ext::CString& aStr) noexcept
+    : ptr(aStr.c_str())
+    , len(aStr.Length())
+{
+}
+
+RED4EXT_INLINE constexpr bool RED4ext::StringView::IsValid() const noexcept
+{
+    return ptr && len > 0u;
+}
+
+RED4EXT_INLINE constexpr RED4ext::StringView::operator bool() const noexcept
+{
+    return IsValid();
+}
+
+RED4EXT_INLINE constexpr bool RED4ext::StringView::operator==(const StringView& aRhs) const noexcept
+{
+    return Length() == aRhs.Length() && std::char_traits<char>::compare(Data(), aRhs.Data(), Length());
+}
+
+RED4EXT_INLINE constexpr bool RED4ext::StringView::operator!=(const StringView& aRhs) const noexcept
+{
+    return !(*this == aRhs);
+}
+
+RED4EXT_INLINE constexpr bool RED4ext::StringView::operator==(const char* aRhs) const noexcept
+{
+    return *this == StringView{aRhs};
+}
+
+RED4EXT_INLINE constexpr bool RED4ext::StringView::operator!=(const char* aRhs) const noexcept
+{
+    return *this != StringView{aRhs};
+}
+
+RED4EXT_INLINE constexpr bool RED4ext::StringView::operator==(std::string_view aRhs) const noexcept
+{
+    return *this == StringView{aRhs};
+}
+
+RED4EXT_INLINE constexpr bool RED4ext::StringView::operator!=(std::string_view aRhs) const noexcept
+{
+    return *this != StringView{aRhs};
+}
+
+RED4EXT_INLINE bool RED4ext::StringView::operator==(const RED4ext::CString& aRhs) const noexcept
+{
+    return *this == StringView{aRhs};
+}
+
+RED4EXT_INLINE bool RED4ext::StringView::operator!=(const RED4ext::CString& aRhs) const noexcept
+{
+    return *this != StringView{aRhs};
+}
+
+RED4EXT_INLINE constexpr char RED4ext::StringView::operator[](std::size_t aIndex) const noexcept
+{
+    return Data()[aIndex];
+}
+
+RED4EXT_INLINE constexpr const char* RED4ext::StringView::Data() const noexcept
+{
+    return ptr;
+}
+
+RED4EXT_INLINE constexpr std::uint32_t RED4ext::StringView::Length() const noexcept
+{
+    return len;
+}
+
+RED4EXT_INLINE constexpr const char* RED4ext::StringView::begin() const noexcept
+{
+    return Data();
+}
+
+RED4EXT_INLINE constexpr const char* RED4ext::StringView::end() const noexcept
+{
+    return Data() + Length();
+}

--- a/include/RED4ext/StringView.hpp
+++ b/include/RED4ext/StringView.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <RED4ext/Common.hpp>
+
+#include <string_view>
+
+namespace RED4ext
+{
+struct CString;
+
+#pragma pack(push, 4)
+struct StringView
+{
+    constexpr StringView() noexcept;
+    constexpr StringView(const char* aStr) noexcept;
+    constexpr StringView(std::string_view aView) noexcept;
+    StringView(const RED4ext::CString& aStr) noexcept;
+
+    constexpr bool IsValid() const noexcept;
+    constexpr operator bool() const noexcept;
+
+    constexpr bool operator==(const StringView& aRhs) const noexcept;
+    constexpr bool operator!=(const StringView& aRhs) const noexcept;
+    constexpr bool operator==(const char* aRhs) const noexcept;
+    constexpr bool operator!=(const char* aRhs) const noexcept;
+    constexpr bool operator==(std::string_view aRhs) const noexcept;
+    constexpr bool operator!=(std::string_view aRhs) const noexcept;
+    bool operator==(const RED4ext::CString& aRhs) const noexcept;
+    bool operator!=(const RED4ext::CString& aRhs) const noexcept;
+
+    constexpr char operator[](std::size_t aIndex) const noexcept;
+
+    constexpr const char* Data() const noexcept;
+    constexpr std::uint32_t Length() const noexcept;
+
+    constexpr const char* begin() const noexcept;
+    constexpr const char* end() const noexcept;
+
+    const char* ptr{};
+    std::uint32_t len{};
+};
+#pragma pack(pop)
+
+RED4EXT_ASSERT_SIZE(StringView, 12u);
+RED4EXT_ASSERT_OFFSET(StringView, ptr, 0u);
+RED4EXT_ASSERT_OFFSET(StringView, len, 8u);
+} // namespace RED4ext
+
+#ifdef RED4EXT_HEADER_ONLY
+#include <RED4ext/StringView-inl.hpp>
+#endif // !RED4EXT_STATIC_LIB

--- a/src/CommandLine.cpp
+++ b/src/CommandLine.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/CommandLine-inl.hpp>

--- a/src/StringView.cpp
+++ b/src/StringView.cpp
@@ -1,0 +1,5 @@
+#ifndef RED4EXT_STATIC_LIB
+#error Please define 'RED4EXT_STATIC_LIB' to compile this file.
+#endif
+
+#include <RED4ext/StringView-inl.hpp>


### PR DESCRIPTION
- Implemented string view class used by REDengine
- Implemented support for reading launch params (NOTE: current functionality only includes checking if param exists, not sure how to get param string yet (like "so\and\so.gamedef" from -gameDefinition so\and\so.gamedef)
- Useful for activating various features on launch parameter (like resetting keybind for overlay if forgotten)