### PR TITLE
Add CurveData::Resize

### DIFF
--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -349,6 +349,39 @@ RED4EXT_INLINE void RED4ext::CurveData<T>::SetPoint(uint32_t aIndex, float aPoin
 }
 
 template<typename T>
+RED4EXT_INLINE void RED4ext::CurveData<T>::Resize(uint32_t aPoints) noexcept
+{
+    if (aPoints == 0)
+    {
+        return;
+    }
+    uint32_t size = GetSize();
+
+    if (aPoints < size)
+    {
+        size = aPoints;
+    }
+    float* points = new float[size];
+    T* values = new T[size];
+    auto* curve = GetCurve();
+
+    std::memcpy(points, curve->GetPoints(), size * sizeof(float));
+    std::memcpy(values, curve->GetValues(), size * sizeof(T));
+
+    buffer.Resize(sizeof(CurveBuffer) + aPoints * sizeof(float) + aPoints * sizeof(T));
+    curve = GetCurve();
+    curve->size = aPoints;
+    curve->unk04 = 0;
+    curve->offsetPoints = 0x10;
+    curve->offsetValues = 0x10 + aPoints * sizeof(T);
+    std::memcpy(curve->GetPoints(), points, size * sizeof(float));
+    std::memcpy(curve->GetValues(), values, size * sizeof(T));
+
+    delete[] points;
+    delete[] values;
+}
+
+template<typename T>
 RED4EXT_INLINE RED4ext::CurvePoint<T> RED4ext::CurveData<T>::operator[](uint32_t aIndex) const noexcept
 {
     return GetPoint(aIndex);

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -349,36 +349,27 @@ RED4EXT_INLINE void RED4ext::CurveData<T>::SetPoint(uint32_t aIndex, float aPoin
 }
 
 template<typename T>
-RED4EXT_INLINE void RED4ext::CurveData<T>::Resize(uint32_t aPoints) noexcept
+RED4EXT_INLINE void RED4ext::CurveData<T>::Resize(uint32_t aNewSize) noexcept
 {
-    if (aPoints == 0)
+    if (aNewSize == 0 || aNewSize == GetSize())
     {
         return;
     }
-    uint32_t size = GetSize();
-
-    if (aPoints < size)
-    {
-        size = aPoints;
-    }
-    float* points = new float[size];
-    T* values = new T[size];
     auto* curve = GetCurve();
+    uint32_t size = curve->size;
 
-    std::memcpy(points, curve->GetPoints(), size * sizeof(float));
-    std::memcpy(values, curve->GetValues(), size * sizeof(T));
-
-    buffer.Resize(sizeof(CurveBuffer) + aPoints * sizeof(float) + aPoints * sizeof(T));
+    if (aNewSize < size)
+    {
+        std::copy_n(curve->GetValues(), aNewSize * sizeof(T), buffer.data + 0x10 * aNewSize * sizeof(float));
+    }
+    buffer.Resize(sizeof(CurveBuffer) + aNewSize * sizeof(float) + aNewSize * sizeof(T));
+    if (aNewSize > size)
+    {
+        std::copy_n(curve->GetValues(), aNewSize * sizeof(T), buffer.data + 0x10 * aNewSize * sizeof(float));
+    }
     curve = GetCurve();
-    curve->size = aPoints;
-    curve->unk04 = 0;
-    curve->offsetPoints = 0x10;
-    curve->offsetValues = 0x10 + aPoints * sizeof(T);
-    std::memcpy(curve->GetPoints(), points, size * sizeof(float));
-    std::memcpy(curve->GetValues(), values, size * sizeof(T));
-
-    delete[] points;
-    delete[] values;
+    curve->size = aNewSize;
+    curve->offsetValues = 0x10 + aNewSize * sizeof(float);
 }
 
 template<typename T>

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -239,7 +239,7 @@ struct CurveBuffer
     uint32_t offsetPoints; // 08
     uint32_t offsetValues; // 12
     // float points[size]; // 16
-    // T values[size];     // 16 + size * sizeof(float)
+    // T values[size];     // 16 + size * sizeof(T)
 };
 RED4EXT_ASSERT_SIZE(CurveBuffer<float>, 0x10);
 RED4EXT_ASSERT_OFFSET(CurveBuffer<float>, size, 0x00);
@@ -255,6 +255,8 @@ struct CurveData
     [[nodiscard]] CurvePoint<T> GetPoint(uint32_t aIndex) const noexcept;
     void SetPoint(uint32_t aIndex, const CurvePoint<T>& acPoint) noexcept;
     void SetPoint(uint32_t aIndex, float aPoint, const T& acValue) noexcept;
+
+    void Resize(uint32_t aPoints) noexcept;
 
     [[nodiscard]] inline CurvePoint<T> operator[](uint32_t aIndex) const noexcept;
 

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -239,7 +239,7 @@ struct CurveBuffer
     uint32_t offsetPoints; // 08
     uint32_t offsetValues; // 12
     // float points[size]; // 16
-    // T values[size];     // 16 + size * sizeof(T)
+    // T values[size];     // 16 + size * sizeof(float)
 };
 RED4EXT_ASSERT_SIZE(CurveBuffer<float>, 0x10);
 RED4EXT_ASSERT_OFFSET(CurveBuffer<float>, size, 0x00);
@@ -256,7 +256,7 @@ struct CurveData
     void SetPoint(uint32_t aIndex, const CurvePoint<T>& acPoint) noexcept;
     void SetPoint(uint32_t aIndex, float aPoint, const T& acValue) noexcept;
 
-    void Resize(uint32_t aPoints) noexcept;
+    void Resize(uint32_t aNewSize) noexcept;
 
     [[nodiscard]] inline CurvePoint<T> operator[](uint32_t aIndex) const noexcept;
 


### PR DESCRIPTION
Allows user to resize the number of points in a CurveData. Data is kept as-is, shrinking will only lose last points, growing will only add random/empty points.

FYI, I haven't tested it myself.