### PR TITLE
Improve error reporting for UniversalReloc class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,13 @@ else()
       "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>"
   )
 
-  target_compile_definitions(RED4ext.SDK PUBLIC RED4EXT_STATIC_LIB)
+  target_compile_definitions(
+    RED4ext.SDK
+      PUBLIC
+        RED4EXT_STATIC_LIB
+      PRIVATE
+        WIN32_LEAN_AND_MEAN
+  )
 
   if(RED4EXT_USE_PCH)
     set(RED4EXT_PCH_FILE "${PROJECT_BINARY_DIR}/red4ext_pch.hpp")

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,5 +12,7 @@ foreach(EXAMPLE_PATH ${EXAMPLE_PATHS})
 
     set_target_properties(${EXAMPLE_NAME} PROPERTIES FOLDER "Examples")
     target_link_libraries(${EXAMPLE_NAME} PRIVATE RED4ext::SDK)
+
+    target_compile_definitions(${EXAMPLE_NAME} PRIVATE WIN32_LEAN_AND_MEAN)
   endif()
 endforeach()

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -13,7 +13,7 @@
 
 RED4EXT_INLINE uintptr_t RED4ext::RelocBase::GetImageBase()
 {
-    static const auto base = reinterpret_cast<uintptr_t>(GetModuleHandle(nullptr));
+    static const auto base = std::bit_cast<uintptr_t>(GetModuleHandle(nullptr));
     return base;
 }
 
@@ -153,7 +153,7 @@ RED4EXT_INLINE RED4ext::UniversalRelocBase::QueryFunc_t RED4ext::UniversalRelocB
 
     const auto handle = GetCurrentModuleHandle();
 
-    const auto func = reinterpret_cast<QueryFunc_t>(GetProcAddress(handle, procName));
+    const auto func = std::bit_cast<QueryFunc_t>(GetProcAddress(handle, procName));
     if (func == nullptr)
     {
         static constexpr auto msg = L"Could not get the 'Query' function for the current mod.\n"

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -45,8 +45,8 @@ RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetCurrentModuleHandle()
 {
     HMODULE result;
 
-    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                           reinterpret_cast<TCHAR*>(UniversalRelocBase::Resolve), &result))
+    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<LPCWSTR>(UniversalRelocBase::Resolve), &result))
     {
         auto msg = L"Unable to retrieve the handle for a plugin.\n"
                    L"Normally, this issue should not happen.\n"

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -49,14 +49,15 @@ RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetRED4extModule()
     const auto handle = GetModuleHandleW(moduleName);
     if (!handle)
     {
-        auto msg = L"The mod you are using could not locate the necessary module (i.e. RED4ext.dll) in the "
-                   L"loaded modules, which is required by the mod to resolve addresses correctly.\n"
-                   L"This may occur if RED4ext is not properly loaded into the current process.\n"
-                   L"\n"
-                   L"Please ensure that RED4ext is correctly installed.\n"
-                   L"\n"
-                   L"If you are the mod's developer, verify that your mod was loaded by RED4ext. "
-                   L"Alternatively, you may need to provide your own address resolver.";
+        static constexpr auto msg =
+            L"The mod you are using could not locate the necessary module (i.e. RED4ext.dll) in the "
+            L"loaded modules, which is required by the mod to resolve addresses correctly.\n"
+            L"This may occur if RED4ext is not properly loaded into the current process.\n"
+            L"\n"
+            L"Please ensure that RED4ext is correctly installed.\n"
+            L"\n"
+            L"If you are the mod's developer, verify that your mod was loaded by RED4ext. "
+            L"Alternatively, you may need to provide your own address resolver.";
 
         ShowErrorAndTerminateProcess(msg, GetLastError());
     }
@@ -74,12 +75,13 @@ RED4EXT_INLINE RED4ext::UniversalRelocBase::ResolveFunc_t RED4ext::UniversalRelo
     const auto func = std::bit_cast<ResolveFunc_t>(GetProcAddress(handle, procName));
     if (func == nullptr)
     {
-        auto msg = L"The mod you are using is unable to find the required address resolver function from RED4ext.\n"
-                   L"This may occur if RED4ext is not properly loaded, OR if the mod is incompatible with the current "
-                   L"version of RED4ext.\n"
-                   L"\n"
-                   L"Please ensure that RED4ext is correctly installed AND that both RED4ext and the mod are "
-                   L"up-to-date.";
+        static constexpr auto msg =
+            L"The mod you are using is unable to find the required address resolver function from RED4ext.\n"
+            L"This may occur if RED4ext is not properly loaded, OR if the mod is incompatible with the current "
+            L"version of RED4ext.\n"
+            L"\n"
+            L"Please ensure that RED4ext is correctly installed AND that both RED4ext and the mod are "
+            L"up-to-date.";
 
         ShowErrorAndTerminateProcess(msg, GetLastError());
     }
@@ -154,12 +156,12 @@ RED4EXT_INLINE RED4ext::UniversalRelocBase::QueryFunc_t RED4ext::UniversalRelocB
     const auto func = reinterpret_cast<QueryFunc_t>(GetProcAddress(handle, procName));
     if (func == nullptr)
     {
-        auto msg = L"Could not get the 'Query' function for the current mod.\n"
-                   L"Normally, this issue should not happen.\n"
-                   L"\n"
-                   L"If you are the mod's developer, verify that your mod was loaded by RED4ext and "
-                   L"that it exports the 'Query' function needed for the mod to interact with "
-                   L"RED4ext. Alternatively, you may need to provide your own address resolver.";
+        static constexpr auto msg = L"Could not get the 'Query' function for the current mod.\n"
+                                    L"Normally, this issue should not happen.\n"
+                                    L"\n"
+                                    L"If you are the mod's developer, verify that your mod was loaded by RED4ext and "
+                                    L"that it exports the 'Query' function needed for the mod to interact with "
+                                    L"RED4ext. Alternatively, you may need to provide your own address resolver.";
 
         ShowErrorAndTerminateProcess(msg, GetLastError(), false);
     }

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -110,16 +110,20 @@ RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetCurrentModuleHandle()
     if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                             reinterpret_cast<LPCWSTR>(UniversalRelocBase::Resolve), &result))
     {
-        auto msg = L"Unable to retrieve the handle for a plugin.\n"
-                   L"Normally, this issue should not happen.\n"
-                   L"\n"
-                   L"What you can do:\n"
-                   L"    1. Disable all mods.\n"
-                   L"    2. Enable them one by one.\n"
-                   L"    3. Start the game after each change to see if the issue happens again.\n"
-                   L"\n"
-                   L"By following these steps, you can identify the mod causing the issue and report it to the mod "
-                   L"author for further assistance.";
+        auto msg =
+            L"Unable to retrieve the handle for a plugin.\n"
+            L"Normally, this issue should not happen.\n"
+            L"\n"
+            L"What you can do:\n"
+            L"    1. Disable all mods.\n"
+            L"    2. Enable them one by one.\n"
+            L"    3. Start the game after each change to see if the issue happens again.\n"
+            L"\n"
+            L"For more detailed instructions on identifying the mod causing the issue, visit the following link:\n"
+            L"    https://tinyurl.com/2zvuctb6\n"
+            L"\n"
+            L"By following these instructions, you can identify the mod causing the issue and report it to the mod "
+            L"author for further assistance.";
 
         MessageBoxW(nullptr, msg, L"RED4ext.SDK", MB_ICONERROR | MB_OK);
         TerminateProcess(GetCurrentProcess(), 1);

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -7,8 +7,6 @@
 #include <mutex>
 #include <sstream>
 
-#include <Windows.h>
-
 #include <RED4ext/Common.hpp>
 #include <RED4ext/Detail/Memory.hpp>
 
@@ -27,50 +25,145 @@ uintptr_t RED4ext::UniversalRelocBase::Resolve(uint32_t aHash)
     }
     else
     {
-        using functionType = uintptr_t (*)(uint32_t);
-        static functionType resolveFunc = nullptr;
-
-        static std::once_flag flag;
-        std::call_once(flag,
-                       []()
-                       {
-                           constexpr auto dllName = "RED4ext.dll";
-                           constexpr auto functionName = "RED4ext_ResolveAddress";
-
-                           auto handle = GetModuleHandleA(dllName);
-                           if (!handle)
-                           {
-                               std::stringstream stream;
-                               stream << "Failed to get '" << dllName
-                                      << "' handle.\nProcess will now close.\n\nLast error: " << GetLastError();
-
-                               MessageBoxA(nullptr, stream.str().c_str(), "RED4ext.SDK", MB_ICONERROR | MB_OK);
-                               TerminateProcess(GetCurrentProcess(), 1);
-                           }
-
-                           resolveFunc = reinterpret_cast<functionType>(GetProcAddress(handle, functionName));
-                           if (resolveFunc == nullptr)
-                           {
-                               std::stringstream stream;
-                               stream << "Failed to get '" << functionName
-                                      << "' address.\nProcess will now close.\n\nLast error: " << GetLastError();
-
-                               MessageBoxA(nullptr, stream.str().c_str(), "RED4ext.SDK", MB_ICONERROR | MB_OK);
-                               TerminateProcess(GetCurrentProcess(), 1);
-                           }
-                       });
+        auto resolveFunc = GetAddressResolverFunction();
 
         auto address = resolveFunc(aHash);
         if (address == 0)
         {
-            std::stringstream stream;
-            stream << "Failed to resolve address for hash " << std::hex << std::showbase << aHash
-                   << ".\nProcess will now close.";
+            std::wostringstream stream;
+            stream << L"Failed to find the address for the hash (" << std::dec << aHash << ") provided by the plugin.\n"
+                   << L"This issue is likely caused by the mod using an incorrect or outdated hash.";
 
-            MessageBoxA(nullptr, stream.str().c_str(), "RED4ext.SDK", MB_ICONERROR | MB_OK);
-            TerminateProcess(GetCurrentProcess(), 1);
+            ShowErrorAndTerminateProcess(stream.str(), GetLastError());
         }
 
         return address;
     }
+}
+
+RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetCurrentModuleHandle()
+{
+    HMODULE result;
+
+    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+                           reinterpret_cast<TCHAR*>(UniversalRelocBase::Resolve), &result))
+    {
+        auto msg = L"Unable to retrieve the handle for a plugin.\n"
+                   L"Normally, this issue should not happen.\n"
+                   L"\n"
+                   L"What you can do:\n"
+                   L"    1. Disable all mods.\n"
+                   L"    2. Enable them one by one.\n"
+                   L"    3. Start the game after each change to see if the issue happens again.\n"
+                   L"\n"
+                   L"By following these steps, you can identify the mod causing the issue and report it to the mod "
+                   L"author for further assistance.";
+
+        MessageBoxW(nullptr, msg, L"RED4ext.SDK", MB_ICONERROR | MB_OK);
+        TerminateProcess(GetCurrentProcess(), 1);
+    }
+
+    return result;
+}
+
+RED4EXT_INLINE std::filesystem::path RED4ext::UniversalRelocBase::GetCurrentModulePath()
+{
+    constexpr auto pathLength = MAX_PATH + 1;
+    auto handle = GetCurrentModuleHandle();
+
+    std::wstring fileName;
+    do
+    {
+        fileName.resize(fileName.size() + pathLength, '\0');
+
+        auto length = GetModuleFileNameW(handle, fileName.data(), static_cast<uint32_t>(fileName.size()));
+        if (length > 0)
+        {
+            // Resize it to the real, std::filesystem::path" will use the string's length instead of recounting it.
+            fileName.resize(length);
+        }
+    } while (GetLastError() == ERROR_INSUFFICIENT_BUFFER);
+
+    return fileName;
+}
+
+RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetRED4extModule()
+{
+    static HMODULE handle{nullptr};
+
+    static std::once_flag flag;
+    std::call_once(flag,
+                   []()
+                   {
+                       constexpr auto moduleName = L"RED4ext.dll";
+
+                       handle = GetModuleHandleW(moduleName);
+                       if (!handle)
+                       {
+                           auto msg =
+                               L"The mod you are using could not locate the necessary module (i.e. RED4ext.dll) in the "
+                               L"loaded modules, which is required by the mod to resolve addresses correctly.\n"
+                               L"This may occur if RED4ext is not properly loaded into the current process.\n"
+                               L"\n"
+                               L"Please ensure that RED4ext is correctly installed.\n"
+                               L"\n"
+                               L"If you are the mod's developer, verify that your mod was loaded by RED4ext. "
+                               L"Alternatively, you may need to provide your own address resolver.";
+
+                           ShowErrorAndTerminateProcess(msg, GetLastError());
+                       }
+                   });
+
+    return handle;
+}
+
+RED4EXT_INLINE RED4ext::UniversalRelocBase::ResolveFunc_t RED4ext::UniversalRelocBase::GetAddressResolverFunction()
+{
+    static ResolveFunc_t func{nullptr};
+
+    static std::once_flag flag;
+    std::call_once(
+        flag,
+        []()
+        {
+            constexpr auto functionName = "RED4ext_ResolveAddress";
+
+            auto handle = GetRED4extModule();
+
+            func = reinterpret_cast<ResolveFunc_t>(GetProcAddress(handle, functionName));
+            if (func == nullptr)
+            {
+                auto msg =
+                    L"The mod you are using is unable to find the required address resolver function from RED4ext.\n"
+                    L"This may occur if RED4ext is not properly loaded, OR if the mod is incompatible with the current "
+                    L"version of RED4ext.\n"
+                    L"\n"
+                    L"Please ensure that RED4ext is correctly installed AND that both RED4ext and the mod are "
+                    L"up-to-date.";
+
+                ShowErrorAndTerminateProcess(msg, GetLastError());
+            }
+        });
+
+    return func;
+}
+
+RED4EXT_INLINE void RED4ext::UniversalRelocBase::ShowErrorAndTerminateProcess(std::wstring_view aMsg,
+                                                                              std::uint32_t aLastError)
+{
+    auto path = GetCurrentModulePath();
+    auto title = path.stem();
+
+    std::wostringstream msg;
+    msg << aMsg << L"\n"
+        << L"-------------------\n"
+        << L"The mod has encountered a critical error and needs to terminate the game's process to prevent unexpected "
+           L"behavior in the game.\n"
+        << L"-------------------\n"
+        << L"Here is some debug information that may help resolve or report the issue:\n"
+        << L"    - Error Code: " << std::dec << aLastError << "\n"
+        << L"    - Mod Path: " << path.c_str();
+
+    MessageBoxW(nullptr, msg.str().c_str(), title.c_str(), MB_ICONERROR | MB_OK);
+    TerminateProcess(GetCurrentProcess(), 1);
 }

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -112,7 +112,9 @@ RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetCurrentModuleHandle()
             L"    3. Start the game after each change to see if the issue happens again.\n"
             L"\n"
             L"For more detailed instructions on identifying the mod causing the issue, visit the following link:\n"
-            L"    https://tinyurl.com/2zvuctb6\n"
+            L"    "
+            L"https://wiki.redmodding.org/cyberpunk-2077-modding/for-mod-users/"
+            L"user-guide-troubleshooting#finding-the-broken-mod-bisecting\n"
             L"\n"
             L"By following these instructions, you can identify the mod causing the issue and report it to the mod "
             L"author for further assistance.";
@@ -218,7 +220,7 @@ RED4EXT_INLINE void RED4ext::UniversalRelocBase::ShowErrorAndTerminateProcess(st
         }
     }
 
-    title += L" - Address Resolver";
+    title += L": Address Resolver";
 
     std::wostringstream msg;
     msg << aMsg << L"\n"
@@ -228,6 +230,7 @@ RED4EXT_INLINE void RED4ext::UniversalRelocBase::ShowErrorAndTerminateProcess(st
         << L"-----------------------------\n"
         << L"Here is some debug information that may help resolve or report the issue:\n"
         << L"    - Error Code (Win32): " << std::dec << aLastError << "\n"
+        << L"    - Plugin: " << title << "\n"
         << L"    - Version: " << version << "\n"
         << L"    - Path: " << path.c_str();
 

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -42,7 +42,7 @@ uintptr_t RED4ext::UniversalRelocBase::Resolve(uint32_t aHash)
     }
 }
 
-RED4EXT_INLINE const HMODULE RED4ext::UniversalRelocBase::GetRED4extModule()
+RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetRED4extModule()
 {
     static constexpr auto moduleName = L"RED4ext.dll";
 
@@ -64,14 +64,14 @@ RED4EXT_INLINE const HMODULE RED4ext::UniversalRelocBase::GetRED4extModule()
     return handle;
 }
 
-RED4EXT_INLINE const RED4ext::UniversalRelocBase::ResolveFunc_t RED4ext::UniversalRelocBase::
+RED4EXT_INLINE RED4ext::UniversalRelocBase::ResolveFunc_t RED4ext::UniversalRelocBase::
     InitializeAddressResolverFunction()
 {
     static constexpr auto procName = "RED4ext_ResolveAddress";
 
     const auto handle = GetRED4extModule();
 
-    auto func = reinterpret_cast<ResolveFunc_t>(GetProcAddress(handle, procName));
+    const auto func = std::bit_cast<ResolveFunc_t>(GetProcAddress(handle, procName));
     if (func == nullptr)
     {
         auto msg = L"The mod you are using is unable to find the required address resolver function from RED4ext.\n"
@@ -87,19 +87,18 @@ RED4EXT_INLINE const RED4ext::UniversalRelocBase::ResolveFunc_t RED4ext::Univers
     return func;
 }
 
-RED4EXT_INLINE const RED4ext::UniversalRelocBase::ResolveFunc_t RED4ext::UniversalRelocBase::
-    GetAddressResolverFunction()
+RED4EXT_INLINE RED4ext::UniversalRelocBase::ResolveFunc_t RED4ext::UniversalRelocBase::GetAddressResolverFunction()
 {
     static const ResolveFunc_t func = InitializeAddressResolverFunction();
     return func;
 }
 
-RED4EXT_INLINE const HMODULE RED4ext::UniversalRelocBase::GetCurrentModuleHandle()
+RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetCurrentModuleHandle()
 {
     HMODULE result;
 
     if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-                            reinterpret_cast<LPCWSTR>(UniversalRelocBase::Resolve), &result))
+                            std::bit_cast<LPCWSTR>(&UniversalRelocBase::Resolve), &result))
     {
         static constexpr auto msg =
             L"Unable to retrieve the handle for a plugin.\n"
@@ -123,7 +122,7 @@ RED4EXT_INLINE const HMODULE RED4ext::UniversalRelocBase::GetCurrentModuleHandle
     return result;
 }
 
-RED4EXT_INLINE const std::filesystem::path RED4ext::UniversalRelocBase::GetCurrentModulePath()
+RED4EXT_INLINE std::filesystem::path RED4ext::UniversalRelocBase::GetCurrentModulePath()
 {
     static constexpr auto pathLength = MAX_PATH;
     const auto handle = GetCurrentModuleHandle();
@@ -146,8 +145,7 @@ RED4EXT_INLINE const std::filesystem::path RED4ext::UniversalRelocBase::GetCurre
     return fileName;
 }
 
-RED4EXT_INLINE const RED4ext::UniversalRelocBase::QueryFunc_t RED4ext::UniversalRelocBase::
-    GetCurrentPluginQueryFunction()
+RED4EXT_INLINE RED4ext::UniversalRelocBase::QueryFunc_t RED4ext::UniversalRelocBase::GetCurrentPluginQueryFunction()
 {
     static constexpr auto procName = "Query";
 

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -222,10 +222,10 @@ RED4EXT_INLINE void RED4ext::UniversalRelocBase::ShowErrorAndTerminateProcess(st
 
     std::wostringstream msg;
     msg << aMsg << L"\n"
-        << L"-------------------\n"
+        << L"-----------------------------\n"
         << L"The mod has encountered a critical error while trying to resolve an address hash and needs to terminate "
            L"the game's process to prevent unexpected behavior in the game.\n"
-        << L"-------------------\n"
+        << L"-----------------------------\n"
         << L"Here is some debug information that may help resolve or report the issue:\n"
         << L"    - Error Code (Win32): " << std::dec << aLastError << "\n"
         << L"    - Version: " << version << "\n"

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -45,7 +45,7 @@ RED4EXT_INLINE HMODULE RED4ext::UniversalRelocBase::GetCurrentModuleHandle()
 {
     HMODULE result;
 
-    if (GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+    if (!GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
                            reinterpret_cast<LPCWSTR>(UniversalRelocBase::Resolve), &result))
     {
         auto msg = L"Unable to retrieve the handle for a plugin.\n"

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -197,8 +197,8 @@ RED4EXT_INLINE void RED4ext::UniversalRelocBase::ShowErrorAndTerminateProcess(st
 {
     const auto path = GetCurrentModulePath();
 
-    std::wstring title = path.stem();
-    std::wstring version = L"Not available (Query was intentionally disabled)";
+    std::wstring pluginName = path.stem();
+    std::wstring pluginVersion = L"Not available (Query was intentionally disabled)";
 
     if (aQueryPluginInfo)
     {
@@ -209,18 +209,18 @@ RED4EXT_INLINE void RED4ext::UniversalRelocBase::ShowErrorAndTerminateProcess(st
         {
             if (pluginInfo.name)
             {
-                title = pluginInfo.name;
+                pluginName = pluginInfo.name;
             }
 
-            version = std::to_wstring(pluginInfo.version);
+            pluginVersion = std::to_wstring(pluginInfo.version);
         }
         else
         {
-            version = L"Not available (Query failed)";
+            pluginVersion = L"Not available (Query failed)";
         }
     }
 
-    title += L": Address Resolver";
+    auto title = pluginName + L": Address Resolver";
 
     std::wostringstream msg;
     msg << aMsg << L"\n"
@@ -230,8 +230,8 @@ RED4EXT_INLINE void RED4ext::UniversalRelocBase::ShowErrorAndTerminateProcess(st
         << L"-----------------------------\n"
         << L"Here is some debug information that may help resolve or report the issue:\n"
         << L"    - Error Code (Win32): " << std::dec << aLastError << "\n"
-        << L"    - Plugin: " << title << "\n"
-        << L"    - Version: " << version << "\n"
+        << L"    - Plugin: " << pluginName << "\n"
+        << L"    - Version: " << pluginVersion << "\n"
         << L"    - Path: " << path.c_str();
 
     MessageBoxW(nullptr, msg.str().c_str(), title.c_str(), MB_ICONERROR | MB_OK);

--- a/include/RED4ext/Relocation-inl.hpp
+++ b/include/RED4ext/Relocation-inl.hpp
@@ -74,7 +74,7 @@ RED4EXT_INLINE std::filesystem::path RED4ext::UniversalRelocBase::GetCurrentModu
     std::wstring fileName;
     do
     {
-        fileName.resize(fileName.size() + pathLength, '\0');
+        fileName.resize(fileName.size() + pathLength, L'\0');
 
         auto length = GetModuleFileNameW(handle, fileName.data(), static_cast<uint32_t>(fileName.size()));
         if (length > 0)

--- a/include/RED4ext/Relocation.hpp
+++ b/include/RED4ext/Relocation.hpp
@@ -95,15 +95,15 @@ private:
     using QueryFunc_t = void (*)(PluginInfo*);
     using ResolveFunc_t = std::uintptr_t (*)(std::uint32_t);
 
-    static const HMODULE GetRED4extModule();
+    static HMODULE GetRED4extModule();
 
-    static const ResolveFunc_t InitializeAddressResolverFunction();
-    static const ResolveFunc_t GetAddressResolverFunction();
+    static ResolveFunc_t InitializeAddressResolverFunction();
+    static ResolveFunc_t GetAddressResolverFunction();
 
-    static const HMODULE GetCurrentModuleHandle();
-    static const std::filesystem::path GetCurrentModulePath();
+    static HMODULE GetCurrentModuleHandle();
+    static std::filesystem::path GetCurrentModulePath();
 
-    static const QueryFunc_t GetCurrentPluginQueryFunction();
+    static QueryFunc_t GetCurrentPluginQueryFunction();
     static bool QueryCurrentPlugin(PluginInfo& aPluginInfo);
 
     static void ShowErrorAndTerminateProcess(std::wstring_view aMsg, std::uint32_t aLastError,

--- a/include/RED4ext/Relocation.hpp
+++ b/include/RED4ext/Relocation.hpp
@@ -104,7 +104,8 @@ private:
     static QueryFunc_t GetCurrentPluginQueryFunction();
     static bool QueryCurrentPlugin(PluginInfo& aPluginInfo);
 
-    static void ShowErrorAndTerminateProcess(std::wstring_view aMsg, std::uint32_t aLastError, bool aQueryPluginInfo = true);
+    static void ShowErrorAndTerminateProcess(std::wstring_view aMsg, std::uint32_t aLastError,
+                                             bool aQueryPluginInfo = true);
 };
 
 /**

--- a/include/RED4ext/Relocation.hpp
+++ b/include/RED4ext/Relocation.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <filesystem>
+#include <string_view>
+
+#include <Windows.h>
 
 namespace RED4ext
 {
@@ -80,11 +84,21 @@ private:
     uintptr_t* m_address;
 };
 
-
 class UniversalRelocBase
 {
 public:
     static uintptr_t Resolve(uint32_t aHash);
+
+private:
+    using ResolveFunc_t = std::uintptr_t (*)(std::uint32_t);
+
+    static HMODULE GetCurrentModuleHandle();
+    static std::filesystem::path GetCurrentModulePath();
+
+    static HMODULE GetRED4extModule();
+    static ResolveFunc_t GetAddressResolverFunction();
+
+    static void ShowErrorAndTerminateProcess(std::wstring_view aMsg, std::uint32_t aLastError);
 };
 
 /**

--- a/include/RED4ext/Relocation.hpp
+++ b/include/RED4ext/Relocation.hpp
@@ -96,6 +96,8 @@ private:
     using ResolveFunc_t = std::uintptr_t (*)(std::uint32_t);
 
     static HMODULE GetRED4extModule();
+
+    static ResolveFunc_t InitializeAddressResolverFunction();
     static ResolveFunc_t GetAddressResolverFunction();
 
     static HMODULE GetCurrentModuleHandle();

--- a/include/RED4ext/Relocation.hpp
+++ b/include/RED4ext/Relocation.hpp
@@ -6,6 +6,8 @@
 
 #include <Windows.h>
 
+#include <RED4ext/Api/Sdk.hpp>
+
 namespace RED4ext
 {
 class RelocBase
@@ -90,15 +92,19 @@ public:
     static uintptr_t Resolve(uint32_t aHash);
 
 private:
+    using QueryFunc_t = void (*)(PluginInfo*);
     using ResolveFunc_t = std::uintptr_t (*)(std::uint32_t);
-
-    static HMODULE GetCurrentModuleHandle();
-    static std::filesystem::path GetCurrentModulePath();
 
     static HMODULE GetRED4extModule();
     static ResolveFunc_t GetAddressResolverFunction();
 
-    static void ShowErrorAndTerminateProcess(std::wstring_view aMsg, std::uint32_t aLastError);
+    static HMODULE GetCurrentModuleHandle();
+    static std::filesystem::path GetCurrentModulePath();
+
+    static QueryFunc_t GetCurrentPluginQueryFunction();
+    static bool QueryCurrentPlugin(PluginInfo& aPluginInfo);
+
+    static void ShowErrorAndTerminateProcess(std::wstring_view aMsg, std::uint32_t aLastError, bool aQueryPluginInfo = true);
 };
 
 /**

--- a/include/RED4ext/Relocation.hpp
+++ b/include/RED4ext/Relocation.hpp
@@ -95,15 +95,15 @@ private:
     using QueryFunc_t = void (*)(PluginInfo*);
     using ResolveFunc_t = std::uintptr_t (*)(std::uint32_t);
 
-    static HMODULE GetRED4extModule();
+    static const HMODULE GetRED4extModule();
 
-    static ResolveFunc_t InitializeAddressResolverFunction();
-    static ResolveFunc_t GetAddressResolverFunction();
+    static const ResolveFunc_t InitializeAddressResolverFunction();
+    static const ResolveFunc_t GetAddressResolverFunction();
 
-    static HMODULE GetCurrentModuleHandle();
-    static std::filesystem::path GetCurrentModulePath();
+    static const HMODULE GetCurrentModuleHandle();
+    static const std::filesystem::path GetCurrentModulePath();
 
-    static QueryFunc_t GetCurrentPluginQueryFunction();
+    static const QueryFunc_t GetCurrentPluginQueryFunction();
     static bool QueryCurrentPlugin(PluginInfo& aPluginInfo);
 
     static void ShowErrorAndTerminateProcess(std::wstring_view aMsg, std::uint32_t aLastError,


### PR DESCRIPTION
This should improve the error message thrown by `UniversalRelocBase` class when an hash is not found. It now include more informational messages for the users, as well as the mod's name in the title, instead of the generic `RED4ext.SDK`, except in the case where we cannot get the plugin's handle, which should never happen.

Some examples:

![image](https://github.com/user-attachments/assets/3007bc13-2f56-439f-9378-9811a352bb7a)
![image](https://github.com/user-attachments/assets/96b0164a-98e5-4ba1-8ed7-4230941e55ff)
![image](https://github.com/user-attachments/assets/58a49199-51f4-444c-a1c3-dc470b3381ef)
![image](https://github.com/user-attachments/assets/bf96f885-388d-4529-8ecb-a49cb380ee16)

