### PR TITLE
Fixed HashMap for uint64 keys

### DIFF
--- a/include/RED4ext/HashMap.hpp
+++ b/include/RED4ext/HashMap.hpp
@@ -39,8 +39,7 @@ struct HashMapHash<T, std::enable_if_t<std::is_same_v<T, uint64_t>>>
 {
     uint32_t operator()(const T& aKey) const noexcept
     {
-        // Not 100% sure if this is correct, but checking quickly seems to be the case for 64bit integers.
-        return static_cast<uint32_t>(aKey) ^ ((aKey >> 32) & 0xFFFFFFFF);
+        return FNV1a32(reinterpret_cast<const uint8_t*>(&aKey), sizeof(uint64_t));
     }
 };
 


### PR DESCRIPTION
Fixed hash function for `uint64_t`. Also checked hashing for `CName`, `TweakDBID`, `ResourcePath` and all of them are still correct at the moment.