### PR TITLE
Cleanup PR #167

### DIFF
--- a/include/RED4ext/GpuApi/Buffer.hpp
+++ b/include/RED4ext/GpuApi/Buffer.hpp
@@ -5,9 +5,7 @@
 #include <d3d12.h>
 #include <wrl/client.h>
 
-namespace RED4ext
-{
-namespace GpuApi
+namespace RED4ext::GpuApi
 {
 struct SBufferData
 {
@@ -19,5 +17,4 @@ struct SBufferData
 };
 RED4EXT_ASSERT_SIZE(SBufferData, 0xa8);
 RED4EXT_ASSERT_OFFSET(SBufferData, bufferResource, 0x10);
-} // namespace GpuApi
-} // namespace RED4ext
+} // namespace RED4ext::GpuApi

--- a/include/RED4ext/GpuApi/CommandListContext-inl.hpp
+++ b/include/RED4ext/GpuApi/CommandListContext-inl.hpp
@@ -6,39 +6,39 @@
 
 #include <RED4ext/Relocation.hpp>
 
-RED4EXT_INLINE void RED4ext::GpuApi::CommandListContext::AddPendingBarrier(const D3D12_RESOURCE_BARRIER& aBarrier)
+namespace RED4ext::GpuApi
+{
+RED4EXT_INLINE void CommandListContext::AddPendingBarrier(const D3D12_RESOURCE_BARRIER& aBarrier)
 {
     using func_t = void (*)(CommandListContext*, const D3D12_RESOURCE_BARRIER&);
     static UniversalRelocFunc<func_t> func(Detail::AddressHashes::CommandListContext_AddPendingBarrier);
     func(this, aBarrier);
 }
 
-RED4EXT_INLINE void RED4ext::GpuApi::CommandListContext::Close()
+RED4EXT_INLINE void CommandListContext::Close()
 {
     using func_t = void (*)(CommandListContext*);
     static UniversalRelocFunc<func_t> func(Detail::AddressHashes::CommandListContext_Close);
     func(this);
 }
 
-RED4EXT_INLINE void RED4ext::GpuApi::CommandListContext::FlushPendingBarriers()
+RED4EXT_INLINE void CommandListContext::FlushPendingBarriers()
 {
     using func_t = void (*)(CommandListContext*);
     static UniversalRelocFunc<func_t> func(Detail::AddressHashes::CommandListContext_FlushPendingBarriers);
     func(this);
 }
 
-RED4EXT_INLINE RED4ext::GpuApi::CommandListContext* AcquireFreeCommandList(RED4ext::GpuApi::CommandListType aType,
-                                                                           RED4ext::StringView& aDebugName,
-                                                                           uint64_t aHash)
+RED4EXT_INLINE CommandListContext* AcquireFreeCommandList(CommandListType aType, const StringView& aDebugName,
+                                                          uint64_t aHash)
 {
     // NOTE: This function has parameters for debug name and hash which seem to be optional.
     // Expects unique ptr as an out param and returns it by reference.
-    using func_t = RED4ext::GpuApi::CommandListContext*& (*)(RED4ext::GpuApi::CommandListContext*&,
-                                                             RED4ext::GpuApi::CommandListType,
-                                                             const RED4ext::StringView&, uint64_t);
-    static RED4ext::UniversalRelocFunc<func_t> func(RED4ext::Detail::AddressHashes::GetFreeCommandList);
+    using func_t = CommandListContext*& (*)(CommandListContext*&, CommandListType, const StringView&, uint64_t);
+    static UniversalRelocFunc<func_t> func(Detail::AddressHashes::GetFreeCommandList);
 
     // TODO: This should be unique_ptr which function fills in and returns.
-    RED4ext::GpuApi::CommandListContext* outContext = nullptr;
+    CommandListContext* outContext = nullptr;
     return func(outContext, aType, aDebugName, aHash);
 }
+} // namespace RED4ext::GpuApi

--- a/include/RED4ext/GpuApi/CommandListContext.hpp
+++ b/include/RED4ext/GpuApi/CommandListContext.hpp
@@ -8,9 +8,7 @@
 #include <d3d12.h>
 #include <wrl/client.h>
 
-namespace RED4ext
-{
-namespace GpuApi
+namespace RED4ext::GpuApi
 {
 enum class CommandListType
 {
@@ -50,8 +48,7 @@ RED4EXT_ASSERT_OFFSET(CommandListContext, pendingBarriers, 0x528);
 CommandListContext* AcquireFreeCommandList(CommandListType aType, const StringView& aDebugName = "",
                                            uint64_t aHash = 0);
 
-} // namespace GpuApi
-} // namespace RED4ext
+} // namespace RED4ext::GpuApi
 
 #ifdef RED4EXT_HEADER_ONLY
 #include <RED4ext/GpuApi/CommandListContext-inl.hpp>

--- a/include/RED4ext/GpuApi/DeviceData-inl.hpp
+++ b/include/RED4ext/GpuApi/DeviceData-inl.hpp
@@ -4,54 +4,11 @@
 #include <RED4ext/GpuApi/DeviceData.hpp>
 #endif
 
-template<typename T, size_t MAX_SIZE>
-bool RED4ext::GpuApi::ResourceContainer<T, MAX_SIZE>::Resource::IsUsed() const
+namespace RED4ext::GpuApi
 {
-    return refCount >= 0;
-}
-
-template<typename T, size_t MAX_SIZE>
-bool RED4ext::GpuApi::ResourceContainer<T, MAX_SIZE>::IsUsedID(const uint32_t id) const
-{
-    return IsValidID(id) && resources[IDToIndex(id)].IsUsed();
-}
-
-template<typename T, size_t MAX_SIZE>
-bool RED4ext::GpuApi::ResourceContainer<T, MAX_SIZE>::IsUnusedID(const uint32_t id) const
-{
-    return IsValidID(id) && !resources[IDToIndex(id)].IsUsed();
-}
-
-template<typename T, size_t MAX_SIZE>
-bool RED4ext::GpuApi::ResourceContainer<T, MAX_SIZE>::IsEmpty() const
-{
-    assert(numUnused <= MAX_SIZE);
-    return numUnused == MAX_SIZE;
-}
-
-template<typename T, size_t MAX_SIZE>
-bool RED4ext::GpuApi::ResourceContainer<T, MAX_SIZE>::IsFull() const
-{
-    assert(numUnused <= MAX_SIZE);
-    return numUnused == 0;
-}
-
-template<typename T, size_t MAX_SIZE>
-T& RED4ext::GpuApi::ResourceContainer<T, MAX_SIZE>::GetData(uint32_t id)
-{
-    assert(IsUsedID(id));
-    return resources[IDToIndex(id)].instance;
-}
-
-template<typename T, size_t MAX_SIZE>
-const T& RED4ext::GpuApi::ResourceContainer<T, MAX_SIZE>::GetData(uint32_t id) const
-{
-    assert(IsUsedID(id));
-    return resources[IDToIndex(id)].instance;
-}
-
 RED4EXT_INLINE RED4ext::GpuApi::SDeviceData* RED4ext::GpuApi::GetDeviceData()
 {
     static UniversalRelocPtr<SDeviceData*> dd(Detail::AddressHashes::g_DeviceData);
     return dd;
 }
+} // namespace RED4ext::GpuApi

--- a/include/RED4ext/GpuApi/DeviceData.hpp
+++ b/include/RED4ext/GpuApi/DeviceData.hpp
@@ -7,9 +7,7 @@
 #include <RED4ext/GpuApi/SwapChain.hpp>
 #include <RED4ext/SpinLock.hpp>
 
-namespace RED4ext
-{
-namespace GpuApi
+namespace RED4ext::GpuApi
 {
 template<typename T, size_t MAX_SIZE>
 struct ResourceContainer
@@ -94,8 +92,53 @@ RED4EXT_ASSERT_OFFSET(SDeviceData, directCommandQueue, 0x13bc4d0);
 RED4EXT_ASSERT_OFFSET(SDeviceData, memoryAllocator, 0x13bc540);
 
 SDeviceData* GetDeviceData();
-} // namespace GpuApi
-} // namespace RED4ext
+
+template<typename T, size_t MAX_SIZE>
+bool ResourceContainer<T, MAX_SIZE>::Resource::IsUsed() const
+{
+    return refCount >= 0;
+}
+
+template<typename T, size_t MAX_SIZE>
+bool ResourceContainer<T, MAX_SIZE>::IsUsedID(const uint32_t id) const
+{
+    return IsValidID(id) && resources[IDToIndex(id)].IsUsed();
+}
+
+template<typename T, size_t MAX_SIZE>
+bool ResourceContainer<T, MAX_SIZE>::IsUnusedID(const uint32_t id) const
+{
+    return IsValidID(id) && !resources[IDToIndex(id)].IsUsed();
+}
+
+template<typename T, size_t MAX_SIZE>
+bool ResourceContainer<T, MAX_SIZE>::IsEmpty() const
+{
+    assert(numUnused <= MAX_SIZE);
+    return numUnused == MAX_SIZE;
+}
+
+template<typename T, size_t MAX_SIZE>
+bool ResourceContainer<T, MAX_SIZE>::IsFull() const
+{
+    assert(numUnused <= MAX_SIZE);
+    return numUnused == 0;
+}
+
+template<typename T, size_t MAX_SIZE>
+T& ResourceContainer<T, MAX_SIZE>::GetData(uint32_t id)
+{
+    assert(IsUsedID(id));
+    return resources[IDToIndex(id)].instance;
+}
+
+template<typename T, size_t MAX_SIZE>
+const T& ResourceContainer<T, MAX_SIZE>::GetData(uint32_t id) const
+{
+    assert(IsUsedID(id));
+    return resources[IDToIndex(id)].instance;
+}
+} // namespace RED4ext::GpuApi
 
 #ifdef RED4EXT_HEADER_ONLY
 #include <RED4ext/GpuApi/DeviceData-inl.hpp>

--- a/include/RED4ext/GpuApi/SwapChain.hpp
+++ b/include/RED4ext/GpuApi/SwapChain.hpp
@@ -5,9 +5,7 @@
 #include <wrl/client.h>
 #include <wrl/wrappers/corewrappers.h>
 
-namespace RED4ext
-{
-namespace GpuApi
+namespace RED4ext::GpuApi
 {
 enum class HDRMode : uint8_t
 {
@@ -52,5 +50,4 @@ RED4EXT_ASSERT_OFFSET(SSwapChainData, presentFenceNextCompletionFrame, 0x60);
 RED4EXT_ASSERT_OFFSET(SSwapChainData, backBufferRtvs, 0x68);
 RED4EXT_ASSERT_OFFSET(SSwapChainData, backBufferUavs, 0x80);
 RED4EXT_ASSERT_OFFSET(SSwapChainData, presentFenceEvent, 0x98);
-} // namespace GpuApi
-} // namespace RED4ext
+} // namespace RED4ext::GpuApi


### PR DESCRIPTION
* compact namespaces
* use namespaces in -inl files
* fix incorrect function signature for RED4ext::GpuApi::AcquireFreeCommandList