### PR TITLE
feat(CGameEngine): add TakeScreenshot method

### DIFF
--- a/include/RED4ext/GameEngine-inl.hpp
+++ b/include/RED4ext/GameEngine-inl.hpp
@@ -12,3 +12,10 @@ RED4EXT_INLINE RED4ext::CGameEngine* RED4ext::CGameEngine::Get()
     static UniversalRelocPtr<CGameEngine*> ptr(Detail::AddressHashes::CGameEngine);
     return ptr;
 }
+
+RED4EXT_INLINE void RED4ext::CGameEngine::TakeScreenshot(const rend::SingleScreenShotData& acData, bool a2)
+{
+    static UniversalRelocFunc<void (*)(CGameEngine*, const rend::SingleScreenShotData*, bool)> func(3668449892);
+
+    func(this, &acData, a2);
+}

--- a/include/RED4ext/GameEngine-inl.hpp
+++ b/include/RED4ext/GameEngine-inl.hpp
@@ -12,10 +12,3 @@ RED4EXT_INLINE RED4ext::CGameEngine* RED4ext::CGameEngine::Get()
     static UniversalRelocPtr<CGameEngine*> ptr(Detail::AddressHashes::CGameEngine);
     return ptr;
 }
-
-RED4EXT_INLINE void RED4ext::CGameEngine::TakeScreenshot(const rend::SingleScreenShotData& acData, bool a2)
-{
-    static UniversalRelocFunc<void (*)(CGameEngine*, const rend::SingleScreenShotData*, bool)> func(3668449892);
-
-    func(this, &acData, a2);
-}

--- a/include/RED4ext/GameEngine.hpp
+++ b/include/RED4ext/GameEngine.hpp
@@ -7,6 +7,7 @@
 #include <RED4ext/DynArray.hpp>
 #include <RED4ext/Handle.hpp>
 #include <RED4ext/HashMap.hpp>
+#include <RED4ext/Scripting/Natives/Generated/rend/SingleScreenShotData.hpp>
 #include <RED4ext/Scripting/Natives/Generated/services/GameServices.hpp>
 
 namespace RED4ext
@@ -202,6 +203,8 @@ RED4EXT_ASSERT_OFFSET(CBaseEngine, isEP1, 0x2D4);
 
 struct BaseGameEngine : CBaseEngine
 {
+    virtual void TakeScreenshot(const rend::SingleScreenShotData& acData, bool a2 = false);
+
     int64_t unk2E8; // 2E8
 };
 RED4EXT_ASSERT_SIZE(BaseGameEngine, 0x2F0);
@@ -220,6 +223,8 @@ struct CGameEngine : BaseGameEngine
     RED4EXT_ASSERT_OFFSET(CGameFramework, gameInstance, 0x10);
 
     static CGameEngine* Get();
+
+    void TakeScreenshot(const rend::SingleScreenShotData& acData, bool a2 = false) override;
 
     int64_t unk2F0;                       // 2F0
     int64_t unk2F8;                       // 2F8

--- a/include/RED4ext/GameEngine.hpp
+++ b/include/RED4ext/GameEngine.hpp
@@ -91,39 +91,39 @@ struct CBaseEngine
     };
     RED4EXT_ASSERT_SIZE(Unk110, 0x10);
 
-    virtual CBaseRTTIType* GetNativeType() = 0;      // 00
-    virtual CBaseRTTIType* GetParentType() = 0;      // 08
-    virtual Memory::IAllocator* GetAllocator() = 0;  // 10
-    virtual ~CBaseEngine() = 0;                      // 18
-    virtual void sub_18() = 0;                       // 20
-    virtual void sub_28() = 0;                       // 28
-    virtual void sub_30() = 0;                       // 30
-    virtual void Terminate(int32_t aExitStatus) = 0; // 38
-    virtual void sub_40() = 0;                       // 40
-    virtual void sub_48() = 0;                       // 48
-    virtual void sub_50() = 0;                       // 50
-    virtual void sub_58() = 0;                       // 58
-    virtual void sub_60() = 0;                       // 60
-    virtual void sub_68() = 0;                       // 68
-    virtual void sub_70() = 0;                       // 70
-    virtual void sub_78() = 0;                       // 78
-    virtual void sub_80() = 0;                       // 80
-    virtual void sub_88() = 0;                       // 88
-    virtual void sub_90() = 0;                       // 90
-    virtual void sub_98() = 0;                       // 98
-    virtual void sub_A0() = 0;                       // A0
-    virtual void sub_A8() = 0;                       // A8
-    virtual void sub_B0() = 0;                       // B0
-    virtual void sub_B8() = 0;                       // B8
-    virtual void sub_C0() = 0;                       // C0
-    virtual void sub_C8(CGameOptions& aOptions) = 0; // C8
-    virtual void sub_D0() = 0;                       // D0
-    virtual void sub_D8() = 0;                       // D8
-    virtual void sub_E0() = 0;                       // E0
-    virtual void sub_E8() = 0;                       // E8
-    virtual void sub_F0() = 0;                       // F0
-    virtual void sub_F8() = 0;                       // F8
-    virtual void sub_100() = 0;                      // 100
+    virtual CBaseRTTIType* GetNativeType() = 0;                                                 // 00
+    virtual CBaseRTTIType* GetParentType() = 0;                                                 // 08
+    virtual Memory::IAllocator* GetAllocator() = 0;                                             // 10
+    virtual ~CBaseEngine() = 0;                                                                 // 18
+    virtual void sub_18() = 0;                                                                  // 20
+    virtual void sub_28() = 0;                                                                  // 28
+    virtual void sub_30() = 0;                                                                  // 30
+    virtual void Terminate(int32_t aExitStatus) = 0;                                            // 38
+    virtual void sub_40() = 0;                                                                  // 40
+    virtual void sub_48() = 0;                                                                  // 48
+    virtual void sub_50() = 0;                                                                  // 50
+    virtual void sub_58() = 0;                                                                  // 58
+    virtual void sub_60() = 0;                                                                  // 60
+    virtual void sub_68() = 0;                                                                  // 68
+    virtual void sub_70() = 0;                                                                  // 70
+    virtual void sub_78() = 0;                                                                  // 78
+    virtual void sub_80() = 0;                                                                  // 80
+    virtual void sub_88() = 0;                                                                  // 88
+    virtual void sub_90() = 0;                                                                  // 90
+    virtual void sub_98() = 0;                                                                  // 98
+    virtual void sub_A0() = 0;                                                                  // A0
+    virtual void sub_A8() = 0;                                                                  // A8
+    virtual void sub_B0() = 0;                                                                  // B0
+    virtual void TakeScreenshot(const rend::SingleScreenShotData& acData, bool a2 = false) = 0; // B8
+    virtual void sub_C0() = 0;                                                                  // C0
+    virtual void sub_C8(CGameOptions& aOptions) = 0;                                            // C8
+    virtual void sub_D0() = 0;                                                                  // D0
+    virtual void sub_D8() = 0;                                                                  // D8
+    virtual void sub_E0() = 0;                                                                  // E0
+    virtual void sub_E8() = 0;                                                                  // E8
+    virtual void sub_F0() = 0;                                                                  // F0
+    virtual void sub_F8() = 0;                                                                  // F8
+    virtual void sub_100() = 0;                                                                 // 100
 
     double unk8;                               // 08
     float unk10;                               // 10
@@ -203,8 +203,6 @@ RED4EXT_ASSERT_OFFSET(CBaseEngine, isEP1, 0x2D4);
 
 struct BaseGameEngine : CBaseEngine
 {
-    virtual void TakeScreenshot(const rend::SingleScreenShotData& acData, bool a2 = false);
-
     int64_t unk2E8; // 2E8
 };
 RED4EXT_ASSERT_SIZE(BaseGameEngine, 0x2F0);
@@ -223,8 +221,6 @@ struct CGameEngine : BaseGameEngine
     RED4EXT_ASSERT_OFFSET(CGameFramework, gameInstance, 0x10);
 
     static CGameEngine* Get();
-
-    void TakeScreenshot(const rend::SingleScreenShotData& acData, bool a2 = false) override;
 
     int64_t unk2F0;                       // 2F0
     int64_t unk2F8;                       // 2F8


### PR DESCRIPTION
Tested locally with simple parameters for `rend::SingleScreenShotData`. Boolean argument is unknown. Trying with both `false`/`true` didn't changed the output in my test. Using `false` as a default anyway.

Many thanks to @Mozz3d for reverse engineering the method 👍 

Edit: hash of the function `3668449892`.