### PR TITLE
Fixed render proxy

### DIFF
--- a/include/RED4ext/RenderProxy.hpp
+++ b/include/RED4ext/RenderProxy.hpp
@@ -10,6 +10,8 @@ namespace RED4ext
 {
 struct IRenderProxy
 {
+    using AllocatorType = Memory::RenderProxyAllocator;
+
     virtual void sub_00();                   // 00
     virtual void sub_08();                   // 08
     virtual ~IRenderProxy() = default;       // 10


### PR DESCRIPTION
`IRenderProxy` was missing allocator type required for `SharedPtr<IRenderProxy>`.