### PR TITLE
Small fixes after #180

### DIFF
--- a/include/RED4ext/Buffer.hpp
+++ b/include/RED4ext/Buffer.hpp
@@ -31,6 +31,9 @@ struct RawBuffer
     RawBuffer(RawBuffer&&) = default;
     ~RawBuffer();
 
+    RawBuffer& operator=(const RawBuffer& aRhs) = delete;
+    RawBuffer& operator=(RawBuffer&& aRhs) = default;
+
     Memory::IAllocator* GetAllocator() const;
     void Initialize(Memory::IAllocator* aAllocator, uint32_t aSize, uint32_t aAlignment = 8);
     void Resize(uint32_t aSize);

--- a/include/RED4ext/Scripting/Natives/MorphTargetMesh.hpp
+++ b/include/RED4ext/Scripting/Natives/MorphTargetMesh.hpp
@@ -2,7 +2,7 @@
 
 #include <RED4ext/CName.hpp>
 #include <RED4ext/Common.hpp>
-#include <RED4ext/DynArray.hpp>
+#include <RED4ext/Containers/DynArray.hpp>
 #include <RED4ext/Handle.hpp>
 #include <RED4ext/NativeTypes.hpp>
 #include <RED4ext/RenderResource.hpp>

--- a/include/RED4ext/Scripting/Natives/animAnimSet.hpp
+++ b/include/RED4ext/Scripting/Natives/animAnimSet.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <RED4ext/Common.hpp>
-#include <RED4ext/DynArray.hpp>
+#include <RED4ext/Containers/DynArray.hpp>
 #include <RED4ext/Handle.hpp>
 #include <RED4ext/NativeTypes.hpp>
 #include <RED4ext/Scripting/Natives/Generated/CResource.hpp>

--- a/include/RED4ext/Scripting/Natives/animRig.hpp
+++ b/include/RED4ext/Scripting/Natives/animRig.hpp
@@ -2,7 +2,7 @@
 
 #include <RED4ext/CName.hpp>
 #include <RED4ext/Common.hpp>
-#include <RED4ext/DynArray.hpp>
+#include <RED4ext/Containers/DynArray.hpp>
 #include <RED4ext/Handle.hpp>
 #include <RED4ext/Scripting/Natives/Generated/CResource.hpp>
 #include <RED4ext/Scripting/Natives/Generated/QsTransform.hpp>

--- a/include/RED4ext/Scripting/Natives/appearanceAppearanceDefinition.hpp
+++ b/include/RED4ext/Scripting/Natives/appearanceAppearanceDefinition.hpp
@@ -2,7 +2,7 @@
 
 #include <RED4ext/CName.hpp>
 #include <RED4ext/Common.hpp>
-#include <RED4ext/DynArray.hpp>
+#include <RED4ext/Containers/DynArray.hpp>
 #include <RED4ext/ISerializable.hpp>
 #include <RED4ext/NativeTypes.hpp>
 #include <RED4ext/Package.hpp>

--- a/include/RED4ext/Scripting/Natives/entEntityTemplate.hpp
+++ b/include/RED4ext/Scripting/Natives/entEntityTemplate.hpp
@@ -2,7 +2,7 @@
 
 #include <RED4ext/CName.hpp>
 #include <RED4ext/Common.hpp>
-#include <RED4ext/DynArray.hpp>
+#include <RED4ext/Containers/DynArray.hpp>
 #include <RED4ext/Handle.hpp>
 #include <RED4ext/NativeTypes.hpp>
 #include <RED4ext/Package.hpp>

--- a/include/RED4ext/Scripting/Natives/inkMultiChildren.hpp
+++ b/include/RED4ext/Scripting/Natives/inkMultiChildren.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <RED4ext/Common.hpp>
-#include <RED4ext/DynArray.hpp>
+#include <RED4ext/Containers/DynArray.hpp>
 #include <RED4ext/Handle.hpp>
 #include <RED4ext/Scripting/Natives/Generated/ink/Children.hpp>
 

--- a/include/RED4ext/SortedArray.hpp
+++ b/include/RED4ext/SortedArray.hpp
@@ -1,0 +1,4 @@
+#pragma once
+#pragma message("WARNING: 'RED4ext/SortedArray.hpp' is deprecated. Please use 'RED4ext/Containers/SortedArray.hpp' instead.")
+
+#include <RED4ext/Containers/SortedArray.hpp>

--- a/include/RED4ext/SortedArray.hpp
+++ b/include/RED4ext/SortedArray.hpp
@@ -1,4 +1,5 @@
 #pragma once
-#pragma message("WARNING: 'RED4ext/SortedArray.hpp' is deprecated. Please use 'RED4ext/Containers/SortedArray.hpp' instead.")
+#pragma message(                                                                                                       \
+    "WARNING: 'RED4ext/SortedArray.hpp' is deprecated. Please use 'RED4ext/Containers/SortedArray.hpp' instead.")
 
 #include <RED4ext/Containers/SortedArray.hpp>

--- a/include/RED4ext/Span.hpp
+++ b/include/RED4ext/Span.hpp
@@ -1,0 +1,4 @@
+#pragma once
+#pragma message("WARNING: 'RED4ext/Span.hpp' is deprecated. Please use 'RED4ext/Containers/Span.hpp' instead.")
+
+#include <RED4ext/Containers/Span.hpp>


### PR DESCRIPTION
- Fixed containers deprecations
- Fixed `RawBuffer` move assignment operator (necessary for new `DynArray::SetCapacity` that moves data)