### PR TITLE
feat(Variant): add FromValue/ToValue helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to
 - Add `TRenderPtr<>`, a smart pointer for types inheriting `IRenderObject` (#194).
 - Add `IRenderResource` (#194).
 - Add parallel jobs support to `JobQueue` (#204).
-- Add `Set`, `Get` and template constructor on `Variant` to support primitive types (#219).
+- Add template utilities on `Variant` to set/get primitive types (#219).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to
 - Add `TRenderPtr<>`, a smart pointer for types inheriting `IRenderObject` (#194).
 - Add `IRenderResource` (#194).
 - Add parallel jobs support to `JobQueue` (#204).
+- Add `Set`, `Get` and template constructor on `Variant` to support primitive types (#219).
 
 ### Changed
 

--- a/examples/variant/Main.cpp
+++ b/examples/variant/Main.cpp
@@ -1,0 +1,73 @@
+#include <RED4ext/NativeTypes-inl.hpp>
+#include <RED4ext/RED4ext.hpp>
+
+RED4EXT_C_EXPORT bool RED4EXT_CALL Main(const RED4ext::v1::PluginHandle aHandle, const RED4ext::v1::EMainReason aReason,
+                                        const RED4ext::v1::Sdk* aSdk)
+{
+    RED4EXT_UNUSED_PARAMETER(aHandle);
+    RED4EXT_UNUSED_PARAMETER(aSdk);
+
+    switch (aReason)
+    {
+    case RED4ext::v1::EMainReason::Load:
+    {
+        RED4ext::v1::GameState state{
+            .OnEnter = [](RED4ext::CGameApplication*) -> bool
+            {
+                {
+                    const auto data = RED4ext::Variant(static_cast<int16_t>(32767));
+                    const auto number = data.Get<int16_t>();
+
+                    assert(number.has_value() == true);
+                    assert(number.value() == 32767);
+                }
+
+                {
+                    RED4ext::Variant data;
+                    data.Set<float>(3.14f);
+                    const auto number = data.Get<float>();
+                    assert(number.has_value() == true);
+                    assert(number.value() == 3.14f);
+                }
+
+                {
+                    constexpr RED4ext::CName kTest = "Hello/World";
+
+                    RED4ext::Variant data;
+                    data.Set<RED4ext::CName>(kTest);
+                    const auto name = data.Get<RED4ext::CName>();
+                    assert(name.has_value() == true);
+                    assert(name.value() == kTest);
+                }
+
+                return false;
+            },
+            .OnUpdate = nullptr,
+            .OnExit = nullptr,
+        };
+        aSdk->gameStates->Add(aHandle, RED4ext::EGameStateType::Running, &state);
+
+        break;
+    }
+    case RED4ext::v1::EMainReason::Unload:
+    {
+        break;
+    }
+    }
+
+    return true;
+}
+
+RED4EXT_C_EXPORT void RED4EXT_CALL Query(RED4ext::v1::PluginInfo* aInfo)
+{
+    aInfo->name = L"RED4ext.Variant";
+    aInfo->author = L"Rayshader";
+    aInfo->version = RED4EXT_V1_SEMVER(1, 0, 0);
+    aInfo->runtime = RED4EXT_V1_RUNTIME_VERSION_LATEST;
+    aInfo->sdk = RED4EXT_V1_SDK_VERSION_CURRENT;
+}
+
+RED4EXT_C_EXPORT uint32_t RED4EXT_CALL Supports()
+{
+    return RED4EXT_API_VERSION_1;
+}

--- a/examples/variant/Main.cpp
+++ b/examples/variant/Main.cpp
@@ -1,5 +1,7 @@
-#include <RED4ext/NativeTypes-inl.hpp>
 #include <RED4ext/RED4ext.hpp>
+#ifdef RED4EXT_STATIC_LIB
+#include <RED4ext/NativeTypes-inl.hpp>
+#endif
 
 RED4EXT_C_EXPORT bool RED4EXT_CALL Main(const RED4ext::v1::PluginHandle aHandle, const RED4ext::v1::EMainReason aReason,
                                         const RED4ext::v1::Sdk* aSdk)

--- a/examples/variant/Main.cpp
+++ b/examples/variant/Main.cpp
@@ -17,6 +17,14 @@ RED4EXT_C_EXPORT bool RED4EXT_CALL Main(const RED4ext::v1::PluginHandle aHandle,
             .OnEnter = [](RED4ext::CGameApplication*) -> bool
             {
                 {
+                    const auto data = RED4ext::ToVariant<RED4ext::CString>("Nova");
+                    const auto number = RED4ext::FromVariant<RED4ext::CString>(data);
+
+                    assert(number.has_value() == true);
+                    assert(number.value() == "Nova");
+                }
+
+                {
                     const auto data = RED4ext::Variant(static_cast<int16_t>(32767));
                     const auto number = data.Get<int16_t>();
 

--- a/examples/variant/Main.cpp
+++ b/examples/variant/Main.cpp
@@ -1,7 +1,4 @@
 #include <RED4ext/RED4ext.hpp>
-#ifdef RED4EXT_STATIC_LIB
-#include <RED4ext/NativeTypes-inl.hpp>
-#endif
 
 RED4EXT_C_EXPORT bool RED4EXT_CALL Main(const RED4ext::v1::PluginHandle aHandle, const RED4ext::v1::EMainReason aReason,
                                         const RED4ext::v1::Sdk* aSdk)
@@ -18,10 +15,10 @@ RED4EXT_C_EXPORT bool RED4EXT_CALL Main(const RED4ext::v1::PluginHandle aHandle,
             {
                 {
                     const auto data = RED4ext::ToVariant<RED4ext::CString>("Nova");
-                    const auto number = RED4ext::FromVariant<RED4ext::CString>(data);
+                    const auto str = RED4ext::FromVariant<RED4ext::CString>(data);
 
-                    assert(number.has_value() == true);
-                    assert(number.value() == "Nova");
+                    assert(str.has_value() == true);
+                    assert(str.value() == "Nova");
                 }
 
                 {

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -405,6 +405,18 @@ RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
 }
 
 template<typename T>
+RED4ext::Variant RED4ext::ToVariant(const T& acValue)
+{
+    return {acValue};
+}
+
+template<typename T>
+std::optional<T> RED4ext::FromVariant(const Variant& acValue)
+{
+    return acValue.Get<T>();
+}
+
+template<typename T>
 RED4EXT_INLINE float* RED4ext::CurveBuffer<T>::GetPoints() noexcept
 {
     return reinterpret_cast<float*>(reinterpret_cast<uint8_t*>(this) + pointsOffset);

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -147,6 +147,12 @@ RED4EXT_INLINE RED4ext::Variant::Variant(RED4ext::CName aTypeName, const void* a
 {
 }
 
+template<RED4ext::rtti::IsNotIType T>
+RED4EXT_INLINE RED4ext::Variant::Variant(const T& acValue)
+    : Variant(GetTypeName<T>(), std::addressof(acValue))
+{
+}
+
 RED4EXT_INLINE RED4ext::Variant::Variant(const Variant& aOther)
     : Variant(aOther.GetType(), aOther.GetDataPtr())
 {
@@ -291,14 +297,22 @@ RED4EXT_INLINE void RED4ext::Variant::Free()
 template<typename T>
 RED4EXT_INLINE bool RED4ext::Variant::Set(const T& acValue)
 {
-    *this = Variant::FromValue(acValue);
-    return !IsEmpty();
+    const auto type = RED4ext::CRTTISystem::Get()->GetType(GetTypeName<T>());
+    return Fill(type, std::addressof(acValue));
 }
 
 template<typename T>
 RED4EXT_INLINE std::optional<T> RED4ext::Variant::Get() const
 {
-    return Variant::ToValue<T>(*this);
+    const auto type = GetType();
+    if (!type || type->GetName() != GetTypeName<T>())
+    {
+        return std::nullopt;
+    }
+
+    T value;
+    Extract(std::addressof(value));
+    return value;
 }
 
 RED4EXT_INLINE bool RED4ext::Variant::CanBeInlined(const RED4ext::rtti::IType* aType) noexcept
@@ -353,31 +367,31 @@ RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
     {
         return "Double";
     }
-    else if constexpr (std::is_same_v<T, CString>)
+    else if constexpr (std::is_same_v<T, RED4ext::CString>)
     {
         return "String";
     }
-    else if constexpr (std::is_same_v<T, CName>)
+    else if constexpr (std::is_same_v<T, RED4ext::CName>)
     {
         return "CName";
     }
-    else if constexpr (std::is_same_v<T, TweakDBID>)
+    else if constexpr (std::is_same_v<T, RED4ext::TweakDBID>)
     {
         return "TweakDBID";
     }
-    else if constexpr (std::is_same_v<T, Vector2>)
+    else if constexpr (std::is_same_v<T, RED4ext::Vector2>)
     {
         return "Vector2";
     }
-    else if constexpr (std::is_same_v<T, Vector3>)
+    else if constexpr (std::is_same_v<T, RED4ext::Vector3>)
     {
         return "Vector3";
     }
-    else if constexpr (std::is_same_v<T, Vector4>)
+    else if constexpr (std::is_same_v<T, RED4ext::Vector4>)
     {
         return "Vector4";
     }
-    else if constexpr (std::is_same_v<T, Quaternion>)
+    else if constexpr (std::is_same_v<T, RED4ext::Quaternion>)
     {
         return "Quaternion";
     }
@@ -388,26 +402,6 @@ RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
         static_assert(false, "Type is currently unsupported.");
         return "";
     }
-}
-
-template<typename T>
-RED4EXT_INLINE RED4ext::Variant RED4ext::Variant::FromValue(const T& acSrc)
-{
-    return RED4ext::Variant{GetTypeName<T>(), std::addressof(acSrc)};
-}
-
-template<typename T>
-RED4EXT_INLINE std::optional<T> RED4ext::Variant::ToValue(const RED4ext::Variant& acSrc)
-{
-    const auto type = acSrc.GetType();
-    if (!type || type->GetName() != GetTypeName<T>())
-    {
-        return std::nullopt;
-    }
-
-    T value;
-    acSrc.Extract(std::addressof(value));
-    return value;
 }
 
 template<typename T>

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -5,6 +5,10 @@
 #endif
 
 #include <RED4ext/RTTISystem.hpp>
+#include <RED4ext/Scripting/Natives/Quaternion.hpp>
+#include <RED4ext/Scripting/Natives/Vector2.hpp>
+#include <RED4ext/Scripting/Natives/Vector3.hpp>
+#include <RED4ext/Scripting/Natives/Vector4.hpp>
 
 RED4EXT_INLINE RED4ext::TweakDBID::TweakDBID(const std::string_view aName) noexcept
 {
@@ -287,6 +291,114 @@ RED4EXT_INLINE void RED4ext::Variant::Free()
 RED4EXT_INLINE bool RED4ext::Variant::CanBeInlined(const RED4ext::rtti::IType* aType) noexcept
 {
     return aType->GetSize() <= InlineSize && aType->GetAlignment() <= InlineAlignment;
+}
+
+template<typename T>
+RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
+{
+    if constexpr (std::is_same_v<T, bool>)
+    {
+        return "Bool";
+    }
+    else if constexpr (std::is_same_v<T, int8_t>)
+    {
+        return "Int8";
+    }
+    else if constexpr (std::is_same_v<T, int16_t>)
+    {
+        return "Int16";
+    }
+    else if constexpr (std::is_same_v<T, int32_t>)
+    {
+        return "Int32";
+    }
+    else if constexpr (std::is_same_v<T, int64_t>)
+    {
+        return "Int64";
+    }
+    else if constexpr (std::is_same_v<T, uint8_t>)
+    {
+        return "Uint8";
+    }
+    else if constexpr (std::is_same_v<T, uint16_t>)
+    {
+        return "Uint16";
+    }
+    else if constexpr (std::is_same_v<T, uint32_t>)
+    {
+        return "Uint32";
+    }
+    else if constexpr (std::is_same_v<T, uint64_t>)
+    {
+        return "Uint64";
+    }
+    else if constexpr (std::is_same_v<T, float>)
+    {
+        return "Float";
+    }
+    else if constexpr (std::is_same_v<T, double>)
+    {
+        return "Double";
+    }
+    else if constexpr (std::is_same_v<T, CString>)
+    {
+        return "String";
+    }
+    else if constexpr (std::is_same_v<T, CName>)
+    {
+        return "CName";
+    }
+    else if constexpr (std::is_same_v<T, TweakDBID>)
+    {
+        return "TweakDBID";
+    }
+    else if constexpr (std::is_same_v<T, Vector2>)
+    {
+        return "Vector2";
+    }
+    else if constexpr (std::is_same_v<T, Vector3>)
+    {
+        return "Vector3";
+    }
+    else if constexpr (std::is_same_v<T, Vector4>)
+    {
+        return "Vector4";
+    }
+    else if constexpr (std::is_same_v<T, Quaternion>)
+    {
+        return "Quaternion";
+    }
+    else
+    {
+        // NOTE: for a better implementation, see RedLib:
+        // https://github.com/psiberx/cp2077-red-lib/blob/master/include/Red/TypeInfo/Resolving.hpp
+        static_assert(false, "Type is currently not implemented.");
+        return "";
+    }
+}
+
+template<typename T>
+RED4EXT_INLINE bool RED4ext::Variant::FromValue(const T& aSrc, Variant& aDst)
+{
+    const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
+    if (!type)
+    {
+        return false;
+    }
+
+    return aDst.Init(type) && aDst.Fill(type, &aSrc);
+}
+
+template<typename T>
+RED4EXT_INLINE bool RED4ext::Variant::ToValue(const Variant& aSrc, T& aDst)
+{
+    const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
+    if (type != aSrc.GetType())
+    {
+        return false;
+    }
+
+    return aSrc.Extract(reinterpret_cast<T*>(&aDst));
 }
 
 template<typename T>

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -383,9 +383,9 @@ RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
     }
     else
     {
-        // NOTE: for a better implementation, see RedLib:
+        // TODO: support all game types and user types using RedLib solution:
         // https://github.com/psiberx/cp2077-red-lib/blob/master/include/Red/TypeInfo/Resolving.hpp
-        static_assert(false, "Type is currently not implemented.");
+        static_assert(false, "Type is currently unsupported.");
         return "";
     }
 }

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -254,7 +254,7 @@ RED4EXT_INLINE bool RED4ext::Variant::Fill(const RED4ext::rtti::IType* aType, co
     return true;
 }
 
-RED4EXT_INLINE bool RED4ext::Variant::Extract(void* aBuffer)
+RED4EXT_INLINE bool RED4ext::Variant::Extract(void* aBuffer) const
 {
     if (IsEmpty())
         return false;

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -297,15 +297,15 @@ RED4EXT_INLINE void RED4ext::Variant::Free()
 template<typename T>
 RED4EXT_INLINE bool RED4ext::Variant::Set(const T& acValue)
 {
-    const auto type = RED4ext::CRTTISystem::Get()->GetType(GetTypeName<T>());
-    return Fill(type, std::addressof(acValue));
+    const auto valueType = RED4ext::CRTTISystem::Get()->GetType(GetTypeName<T>());
+    return Fill(valueType, std::addressof(acValue));
 }
 
 template<typename T>
 RED4EXT_INLINE std::optional<T> RED4ext::Variant::Get() const
 {
-    const auto type = GetType();
-    if (!type || type->GetName() != GetTypeName<T>())
+    const auto valueType = GetType();
+    if (!valueType || valueType->GetName() != GetTypeName<T>())
     {
         return std::nullopt;
     }

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -390,6 +390,14 @@ RED4EXT_INLINE bool RED4ext::Variant::FromValue(const T& aSrc, RED4ext::Variant&
 }
 
 template<typename T>
+RED4EXT_INLINE RED4ext::Variant RED4ext::Variant::FromValue(const T& aSrc)
+{
+    RED4ext::Variant dst;
+    FromValue(aSrc, dst);
+    return dst;
+}
+
+template<typename T>
 RED4EXT_INLINE bool RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc, T& aDst)
 {
     const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
@@ -399,6 +407,14 @@ RED4EXT_INLINE bool RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc, T& a
     }
 
     return aSrc.Extract(reinterpret_cast<void*>(&aDst));
+}
+
+template<typename T>
+RED4EXT_INLINE T RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc)
+{
+    T dst;
+    ToValue(aSrc, dst);
+    return dst;
 }
 
 template<typename T>

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -288,6 +288,18 @@ RED4EXT_INLINE void RED4ext::Variant::Free()
     type = nullptr;
 }
 
+template<typename T>
+RED4EXT_INLINE bool RED4ext::Variant::Set(const T& aValue)
+{
+    return Variant::FromValue<T>(aValue, *this);
+}
+
+template<typename T>
+RED4EXT_INLINE T RED4ext::Variant::Get() const
+{
+    return Variant::ToValue<T>(*this);
+}
+
 RED4EXT_INLINE bool RED4ext::Variant::CanBeInlined(const RED4ext::rtti::IType* aType) noexcept
 {
     return aType->GetSize() <= InlineSize && aType->GetAlignment() <= InlineAlignment;

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -297,7 +297,7 @@ RED4EXT_INLINE void RED4ext::Variant::Free()
 template<typename T>
 RED4EXT_INLINE bool RED4ext::Variant::Set(const T& acValue)
 {
-    const auto valueType = RED4ext::CRTTISystem::Get()->GetType(GetTypeName<T>());
+    const auto valueType = CRTTISystem::Get()->GetType(GetTypeName<T>());
     return Fill(valueType, std::addressof(acValue));
 }
 
@@ -311,7 +311,10 @@ RED4EXT_INLINE std::optional<T> RED4ext::Variant::Get() const
     }
 
     T value;
-    Extract(std::addressof(value));
+    if (!Extract(std::addressof(value)))
+    {
+        return std::nullopt;
+    }
     return value;
 }
 

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -381,27 +381,20 @@ template<typename T>
 RED4EXT_INLINE bool RED4ext::Variant::FromValue(const T& aSrc, RED4ext::Variant& aDst)
 {
     const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
-    if (!type)
-    {
-        return false;
-    }
-
-    return aDst.Init(type) && aDst.Fill(type, const_cast<void*>(reinterpret_cast<const void*>(&aSrc)));
+    return aDst.Fill(type, const_cast<void*>(&aSrc));
 }
 
 template<typename T>
-RED4EXT_INLINE RED4ext::Variant RED4ext::Variant::FromValue(const T& aSrc)
+RED4EXT_INLINE RED4ext::Variant RED4ext::Variant::FromValue(const T& aValue)
 {
-    RED4ext::Variant dst;
-    FromValue(aSrc, dst);
-    return dst;
+    return RED4ext::Variant{GetTypeName<T>(), const_cast<void*>(reinterpret_cast<const void*>(&aValue))};
 }
 
 template<typename T>
 RED4EXT_INLINE bool RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc, T& aDst)
 {
-    const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
-    if (type != aSrc.GetType())
+    const auto type = aSrc.GetType();
+    if (!type || type->GetName() != GetTypeName<T>())
     {
         return false;
     }
@@ -412,9 +405,15 @@ RED4EXT_INLINE bool RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc, T& a
 template<typename T>
 RED4EXT_INLINE T RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc)
 {
-    T dst;
-    ToValue(aSrc, dst);
-    return dst;
+    const auto type = aSrc.GetType();
+    if (!type || type->GetName() != GetTypeName<T>())
+    {
+        return T();
+    }
+
+    T value;
+    aSrc.Extract(&value);
+    return value;
 }
 
 template<typename T>

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -367,31 +367,31 @@ RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
     {
         return "Double";
     }
-    else if constexpr (std::is_same_v<T, RED4ext::CString>)
+    else if constexpr (std::is_same_v<T, CString>)
     {
         return "String";
     }
-    else if constexpr (std::is_same_v<T, RED4ext::CName>)
+    else if constexpr (std::is_same_v<T, CName>)
     {
         return "CName";
     }
-    else if constexpr (std::is_same_v<T, RED4ext::TweakDBID>)
+    else if constexpr (std::is_same_v<T, TweakDBID>)
     {
         return "TweakDBID";
     }
-    else if constexpr (std::is_same_v<T, RED4ext::Vector2>)
+    else if constexpr (std::is_same_v<T, Vector2>)
     {
         return "Vector2";
     }
-    else if constexpr (std::is_same_v<T, RED4ext::Vector3>)
+    else if constexpr (std::is_same_v<T, Vector3>)
     {
         return "Vector3";
     }
-    else if constexpr (std::is_same_v<T, RED4ext::Vector4>)
+    else if constexpr (std::is_same_v<T, Vector4>)
     {
         return "Vector4";
     }
-    else if constexpr (std::is_same_v<T, RED4ext::Quaternion>)
+    else if constexpr (std::is_same_v<T, Quaternion>)
     {
         return "Quaternion";
     }

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -378,7 +378,7 @@ RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
 }
 
 template<typename T>
-RED4EXT_INLINE bool RED4ext::Variant::FromValue(const T& aSrc, Variant& aDst)
+RED4EXT_INLINE bool RED4ext::Variant::FromValue(const T& aSrc, RED4ext::Variant& aDst)
 {
     const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
     if (!type)
@@ -386,11 +386,11 @@ RED4EXT_INLINE bool RED4ext::Variant::FromValue(const T& aSrc, Variant& aDst)
         return false;
     }
 
-    return aDst.Init(type) && aDst.Fill(type, &aSrc);
+    return aDst.Init(type) && aDst.Fill(type, const_cast<void*>(reinterpret_cast<const void*>(&aSrc)));
 }
 
 template<typename T>
-RED4EXT_INLINE bool RED4ext::Variant::ToValue(const Variant& aSrc, T& aDst)
+RED4EXT_INLINE bool RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc, T& aDst)
 {
     const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
     if (type != aSrc.GetType())
@@ -398,7 +398,7 @@ RED4EXT_INLINE bool RED4ext::Variant::ToValue(const Variant& aSrc, T& aDst)
         return false;
     }
 
-    return aSrc.Extract(reinterpret_cast<T*>(&aDst));
+    return aSrc.Extract(reinterpret_cast<void*>(&aDst));
 }
 
 template<typename T>

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -289,13 +289,14 @@ RED4EXT_INLINE void RED4ext::Variant::Free()
 }
 
 template<typename T>
-RED4EXT_INLINE bool RED4ext::Variant::Set(const T& aValue)
+RED4EXT_INLINE bool RED4ext::Variant::Set(const T& acValue)
 {
-    return Variant::FromValue<T>(aValue, *this);
+    *this = Variant::FromValue(acValue);
+    return !IsEmpty();
 }
 
 template<typename T>
-RED4EXT_INLINE T RED4ext::Variant::Get() const
+RED4EXT_INLINE std::optional<T> RED4ext::Variant::Get() const
 {
     return Variant::ToValue<T>(*this);
 }
@@ -390,41 +391,22 @@ RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
 }
 
 template<typename T>
-RED4EXT_INLINE bool RED4ext::Variant::FromValue(const T& aSrc, RED4ext::Variant& aDst)
+RED4EXT_INLINE RED4ext::Variant RED4ext::Variant::FromValue(const T& acSrc)
 {
-    const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
-    return aDst.Fill(type, const_cast<void*>(reinterpret_cast<const void*>(&aSrc)));
+    return RED4ext::Variant{GetTypeName<T>(), std::addressof(acSrc)};
 }
 
 template<typename T>
-RED4EXT_INLINE RED4ext::Variant RED4ext::Variant::FromValue(const T& aValue)
+RED4EXT_INLINE std::optional<T> RED4ext::Variant::ToValue(const RED4ext::Variant& acSrc)
 {
-    return RED4ext::Variant{GetTypeName<T>(), const_cast<void*>(reinterpret_cast<const void*>(&aValue))};
-}
-
-template<typename T>
-RED4EXT_INLINE bool RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc, T& aDst)
-{
-    const auto type = aSrc.GetType();
+    const auto type = acSrc.GetType();
     if (!type || type->GetName() != GetTypeName<T>())
     {
-        return false;
-    }
-
-    return aSrc.Extract(reinterpret_cast<void*>(&aDst));
-}
-
-template<typename T>
-RED4EXT_INLINE T RED4ext::Variant::ToValue(const RED4ext::Variant& aSrc)
-{
-    const auto type = aSrc.GetType();
-    if (!type || type->GetName() != GetTypeName<T>())
-    {
-        return T();
+        return std::nullopt;
     }
 
     T value;
-    aSrc.Extract(&value);
+    acSrc.Extract(std::addressof(value));
     return value;
 }
 

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -4,12 +4,6 @@
 #include <RED4ext/NativeTypes.hpp>
 #endif
 
-#include <RED4ext/RTTISystem.hpp>
-#include <RED4ext/Scripting/Natives/Quaternion.hpp>
-#include <RED4ext/Scripting/Natives/Vector2.hpp>
-#include <RED4ext/Scripting/Natives/Vector3.hpp>
-#include <RED4ext/Scripting/Natives/Vector4.hpp>
-
 RED4EXT_INLINE RED4ext::TweakDBID::TweakDBID(const std::string_view aName) noexcept
 {
     size_t len = aName.size();
@@ -144,12 +138,6 @@ RED4EXT_INLINE RED4ext::Variant::Variant(RED4ext::CName aTypeName)
 
 RED4EXT_INLINE RED4ext::Variant::Variant(RED4ext::CName aTypeName, const void* aData)
     : Variant(RED4ext::CRTTISystem::Get()->GetType(aTypeName), aData)
-{
-}
-
-template<RED4ext::rtti::IsNotIType T>
-RED4EXT_INLINE RED4ext::Variant::Variant(const T& acValue)
-    : Variant(GetTypeName<T>(), std::addressof(acValue))
 {
 }
 
@@ -294,129 +282,9 @@ RED4EXT_INLINE void RED4ext::Variant::Free()
     type = nullptr;
 }
 
-template<typename T>
-RED4EXT_INLINE bool RED4ext::Variant::Set(const T& acValue)
-{
-    const auto valueType = CRTTISystem::Get()->GetType(GetTypeName<T>());
-    return Fill(valueType, std::addressof(acValue));
-}
-
-template<typename T>
-RED4EXT_INLINE std::optional<T> RED4ext::Variant::Get() const
-{
-    const auto valueType = GetType();
-    if (!valueType || valueType->GetName() != GetTypeName<T>())
-    {
-        return std::nullopt;
-    }
-
-    T value;
-    if (!Extract(std::addressof(value)))
-    {
-        return std::nullopt;
-    }
-    return value;
-}
-
 RED4EXT_INLINE bool RED4ext::Variant::CanBeInlined(const RED4ext::rtti::IType* aType) noexcept
 {
     return aType->GetSize() <= InlineSize && aType->GetAlignment() <= InlineAlignment;
-}
-
-template<typename T>
-RED4EXT_INLINE consteval RED4ext::CName RED4ext::Variant::GetTypeName()
-{
-    if constexpr (std::is_same_v<T, bool>)
-    {
-        return "Bool";
-    }
-    else if constexpr (std::is_same_v<T, int8_t>)
-    {
-        return "Int8";
-    }
-    else if constexpr (std::is_same_v<T, int16_t>)
-    {
-        return "Int16";
-    }
-    else if constexpr (std::is_same_v<T, int32_t>)
-    {
-        return "Int32";
-    }
-    else if constexpr (std::is_same_v<T, int64_t>)
-    {
-        return "Int64";
-    }
-    else if constexpr (std::is_same_v<T, uint8_t>)
-    {
-        return "Uint8";
-    }
-    else if constexpr (std::is_same_v<T, uint16_t>)
-    {
-        return "Uint16";
-    }
-    else if constexpr (std::is_same_v<T, uint32_t>)
-    {
-        return "Uint32";
-    }
-    else if constexpr (std::is_same_v<T, uint64_t>)
-    {
-        return "Uint64";
-    }
-    else if constexpr (std::is_same_v<T, float>)
-    {
-        return "Float";
-    }
-    else if constexpr (std::is_same_v<T, double>)
-    {
-        return "Double";
-    }
-    else if constexpr (std::is_same_v<T, CString>)
-    {
-        return "String";
-    }
-    else if constexpr (std::is_same_v<T, CName>)
-    {
-        return "CName";
-    }
-    else if constexpr (std::is_same_v<T, TweakDBID>)
-    {
-        return "TweakDBID";
-    }
-    else if constexpr (std::is_same_v<T, Vector2>)
-    {
-        return "Vector2";
-    }
-    else if constexpr (std::is_same_v<T, Vector3>)
-    {
-        return "Vector3";
-    }
-    else if constexpr (std::is_same_v<T, Vector4>)
-    {
-        return "Vector4";
-    }
-    else if constexpr (std::is_same_v<T, Quaternion>)
-    {
-        return "Quaternion";
-    }
-    else
-    {
-        // TODO: support all game types and user types using RedLib solution:
-        // https://github.com/psiberx/cp2077-red-lib/blob/master/include/Red/TypeInfo/Resolving.hpp
-        static_assert(false, "Type is currently unsupported.");
-        return "";
-    }
-}
-
-template<typename T>
-RED4ext::Variant RED4ext::ToVariant(const T& acValue)
-{
-    return {acValue};
-}
-
-template<typename T>
-std::optional<T> RED4ext::FromVariant(const Variant& acValue)
-{
-    return acValue.Get<T>();
 }
 
 template<typename T>

--- a/include/RED4ext/NativeTypes-inl.hpp
+++ b/include/RED4ext/NativeTypes-inl.hpp
@@ -393,7 +393,7 @@ template<typename T>
 RED4EXT_INLINE bool RED4ext::Variant::FromValue(const T& aSrc, RED4ext::Variant& aDst)
 {
     const auto type = CRTTISystem::Get()->GetType(GetTypeName<T>());
-    return aDst.Fill(type, const_cast<void*>(&aSrc));
+    return aDst.Fill(type, const_cast<void*>(reinterpret_cast<const void*>(&aSrc)));
 }
 
 template<typename T>

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -14,6 +14,7 @@
 #include <RED4ext/Hashing/CRC.hpp>
 #include <RED4ext/InstanceType.hpp>
 #include <RED4ext/NodeRef.hpp>
+#include <RED4ext/RTTITypes.hpp>
 #include <RED4ext/ResourceReference.hpp>
 #include <RED4ext/Scripting/Natives/Generated/curve/EInterpolationType.hpp>
 #include <RED4ext/Scripting/Natives/Generated/curve/ESegmentsLinkType.hpp>
@@ -155,6 +156,8 @@ struct Variant
     Variant(const rtti::IType* aType, const void* aData);
     Variant(CName aTypeName);
     Variant(CName aTypeName, const void* aData);
+    template<rtti::IsNotIType T>
+    Variant(const T& acValue);
     Variant(const Variant& aOther);
     Variant(Variant&& aOther) noexcept;
     ~Variant();
@@ -183,12 +186,6 @@ struct Variant
 
     template<typename T>
     static consteval CName GetTypeName();
-
-    template<typename T>
-    static Variant FromValue(const T& acSrc);
-
-    template<typename T>
-    static std::optional<T> ToValue(const Variant& acSrc);
 
     const rtti::IType* type{nullptr};
     union

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -172,6 +172,12 @@ struct Variant
     bool Extract(void* aBuffer) const;
     void Free();
 
+    template<typename T>
+    bool Set(const T& aValue);
+
+    template<typename T>
+    [[nodiscard]] T Get() const;
+
     static bool CanBeInlined(const rtti::IType* aType) noexcept;
 
     template<typename T>

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -196,6 +196,12 @@ struct Variant
 };
 RED4EXT_ASSERT_SIZE(Variant, 0x18);
 
+template<typename T>
+[[nodiscard]] Variant ToVariant(const T& acValue);
+
+template<typename T>
+[[nodiscard]] std::optional<T> FromVariant(const Variant& acValue);
+
 struct gamedataLocKeyWrapper
 {
     gamedataLocKeyWrapper() noexcept;

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -14,10 +14,15 @@
 #include <RED4ext/Hashing/CRC.hpp>
 #include <RED4ext/InstanceType.hpp>
 #include <RED4ext/NodeRef.hpp>
+#include <RED4ext/RTTISystem.hpp>
 #include <RED4ext/RTTITypes.hpp>
 #include <RED4ext/ResourceReference.hpp>
 #include <RED4ext/Scripting/Natives/Generated/curve/EInterpolationType.hpp>
 #include <RED4ext/Scripting/Natives/Generated/curve/ESegmentsLinkType.hpp>
+#include <RED4ext/Scripting/Natives/Quaternion.hpp>
+#include <RED4ext/Scripting/Natives/Vector2.hpp>
+#include <RED4ext/Scripting/Natives/Vector3.hpp>
+#include <RED4ext/Scripting/Natives/Vector4.hpp>
 
 namespace RED4ext
 {
@@ -157,7 +162,10 @@ struct Variant
     Variant(CName aTypeName);
     Variant(CName aTypeName, const void* aData);
     template<rtti::IsNotIType T>
-    Variant(const T& acValue);
+    Variant(const T& acValue)
+        : Variant(GetTypeName<T>(), std::addressof(acValue))
+    {
+    }
     Variant(const Variant& aOther);
     Variant(Variant&& aOther) noexcept;
     ~Variant();
@@ -177,15 +185,114 @@ struct Variant
     void Free();
 
     template<typename T>
-    bool Set(const T& acValue);
+    bool Set(const T& acValue)
+    {
+        const auto valueType = CRTTISystem::Get()->GetType(GetTypeName<T>());
+        return Fill(valueType, std::addressof(acValue));
+    }
 
     template<typename T>
-    [[nodiscard]] std::optional<T> Get() const;
+    [[nodiscard]] std::optional<T> Get() const
+    {
+        const auto valueType = GetType();
+        if (!valueType || valueType->GetName() != GetTypeName<T>())
+        {
+            return std::nullopt;
+        }
+
+        T value;
+        if (!Extract(std::addressof(value)))
+        {
+            return std::nullopt;
+        }
+        return value;
+    }
 
     static bool CanBeInlined(const rtti::IType* aType) noexcept;
 
     template<typename T>
-    static consteval CName GetTypeName();
+    static consteval CName GetTypeName()
+    {
+        if constexpr (std::is_same_v<T, bool>)
+        {
+            return "Bool";
+        }
+        else if constexpr (std::is_same_v<T, int8_t>)
+        {
+            return "Int8";
+        }
+        else if constexpr (std::is_same_v<T, int16_t>)
+        {
+            return "Int16";
+        }
+        else if constexpr (std::is_same_v<T, int32_t>)
+        {
+            return "Int32";
+        }
+        else if constexpr (std::is_same_v<T, int64_t>)
+        {
+            return "Int64";
+        }
+        else if constexpr (std::is_same_v<T, uint8_t>)
+        {
+            return "Uint8";
+        }
+        else if constexpr (std::is_same_v<T, uint16_t>)
+        {
+            return "Uint16";
+        }
+        else if constexpr (std::is_same_v<T, uint32_t>)
+        {
+            return "Uint32";
+        }
+        else if constexpr (std::is_same_v<T, uint64_t>)
+        {
+            return "Uint64";
+        }
+        else if constexpr (std::is_same_v<T, float>)
+        {
+            return "Float";
+        }
+        else if constexpr (std::is_same_v<T, double>)
+        {
+            return "Double";
+        }
+        else if constexpr (std::is_same_v<T, CString>)
+        {
+            return "String";
+        }
+        else if constexpr (std::is_same_v<T, CName>)
+        {
+            return "CName";
+        }
+        else if constexpr (std::is_same_v<T, TweakDBID>)
+        {
+            return "TweakDBID";
+        }
+        else if constexpr (std::is_same_v<T, Vector2>)
+        {
+            return "Vector2";
+        }
+        else if constexpr (std::is_same_v<T, Vector3>)
+        {
+            return "Vector3";
+        }
+        else if constexpr (std::is_same_v<T, Vector4>)
+        {
+            return "Vector4";
+        }
+        else if constexpr (std::is_same_v<T, Quaternion>)
+        {
+            return "Quaternion";
+        }
+        else
+        {
+            // TODO: support all game types and user types using RedLib solution:
+            // https://github.com/psiberx/cp2077-red-lib/blob/master/include/Red/TypeInfo/Resolving.hpp
+            static_assert(false, "Type is currently unsupported.");
+            return "";
+        }
+    }
 
     const rtti::IType* type{nullptr};
     union
@@ -197,10 +304,16 @@ struct Variant
 RED4EXT_ASSERT_SIZE(Variant, 0x18);
 
 template<typename T>
-[[nodiscard]] Variant ToVariant(const T& acValue);
+[[nodiscard]] Variant ToVariant(const T& acValue)
+{
+    return {acValue};
+}
 
 template<typename T>
-[[nodiscard]] std::optional<T> FromVariant(const Variant& acValue);
+[[nodiscard]] std::optional<T> FromVariant(const Variant& acValue)
+{
+    return acValue.Get<T>();
+}
 
 struct gamedataLocKeyWrapper
 {

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -181,7 +181,13 @@ struct Variant
     static bool FromValue(const T& aSrc, Variant& aDst);
 
     template<typename T>
+    static Variant FromValue(const T& aSrc);
+
+    template<typename T>
     static bool ToValue(const Variant& aSrc, T& aDst);
+
+    template<typename T>
+    static T ToValue(const Variant& aSrc);
 
     const rtti::IType* type{nullptr};
     union

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -174,6 +174,15 @@ struct Variant
 
     static bool CanBeInlined(const rtti::IType* aType) noexcept;
 
+    template<typename T>
+    static consteval CName GetTypeName();
+
+    template<typename T>
+    static bool FromValue(const T& aSrc, Variant& aDst);
+
+    template<typename T>
+    static bool ToValue(const Variant& aSrc, T& aDst);
+
     const rtti::IType* type{nullptr};
     union
     {

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -169,7 +169,7 @@ struct Variant
 
     bool Init(const rtti::IType* aType);
     bool Fill(const rtti::IType* aType, const void* aData);
-    bool Extract(void* aBuffer);
+    bool Extract(void* aBuffer) const;
     void Free();
 
     static bool CanBeInlined(const rtti::IType* aType) noexcept;

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <string_view>
 
 #include <RED4ext/Buffer.hpp>
@@ -173,10 +174,10 @@ struct Variant
     void Free();
 
     template<typename T>
-    bool Set(const T& aValue);
+    bool Set(const T& acValue);
 
     template<typename T>
-    [[nodiscard]] T Get() const;
+    [[nodiscard]] std::optional<T> Get() const;
 
     static bool CanBeInlined(const rtti::IType* aType) noexcept;
 
@@ -184,16 +185,10 @@ struct Variant
     static consteval CName GetTypeName();
 
     template<typename T>
-    static bool FromValue(const T& aSrc, Variant& aDst);
+    static Variant FromValue(const T& acSrc);
 
     template<typename T>
-    static Variant FromValue(const T& aSrc);
-
-    template<typename T>
-    static bool ToValue(const Variant& aSrc, T& aDst);
-
-    template<typename T>
-    static T ToValue(const Variant& aSrc);
+    static std::optional<T> ToValue(const Variant& acSrc);
 
     const rtti::IType* type{nullptr};
     union

--- a/include/RED4ext/NativeTypes.hpp
+++ b/include/RED4ext/NativeTypes.hpp
@@ -161,8 +161,9 @@ struct Variant
     Variant(const rtti::IType* aType, const void* aData);
     Variant(CName aTypeName);
     Variant(CName aTypeName, const void* aData);
-    template<rtti::IsNotIType T>
-    Variant(const T& acValue)
+    template<typename T>
+    requires !std::derived_from<std::remove_pointer_t<std::decay_t<T>>, rtti::IType>
+             Variant(const T& acValue)
         : Variant(GetTypeName<T>(), std::addressof(acValue))
     {
     }

--- a/include/RED4ext/RTTI/IType.hpp
+++ b/include/RED4ext/RTTI/IType.hpp
@@ -83,9 +83,6 @@ struct IType
     void* unk8;
 };
 RED4EXT_ASSERT_SIZE(IType, 0x10);
-
-template<typename T>
-concept IsNotIType = !std::derived_from<std::remove_pointer_t<std::decay_t<T>>, IType>;
 } // namespace rtti
 } // namespace RED4ext
 

--- a/include/RED4ext/RTTI/IType.hpp
+++ b/include/RED4ext/RTTI/IType.hpp
@@ -83,6 +83,9 @@ struct IType
     void* unk8;
 };
 RED4EXT_ASSERT_SIZE(IType, 0x10);
+
+template<typename T>
+concept IsNotIType = !std::derived_from<std::remove_pointer_t<std::decay_t<T>>, IType>;
 } // namespace rtti
 } // namespace RED4ext
 


### PR DESCRIPTION
**Changes**
- convert a `Variant` to/from a value. Support fundamental and common types.
- add constness on `Extract` method, implementation is already readonly.

**Usages**
Static:
```cpp
RED4ext::Variant data;
RED4ext::Variant::FromValue<uint64_t>(42, data); // return false on error

uint64_t hash;
RED4ext::Variant::ToValue(data, hash); // return false on error
```

Static without direct error feedback:
```cpp
RED4ext::Variant data = RED4ext::Variant::FromValue<uint64_t>(42);
const auto hash = RED4ext::Variant::ToValue<uint64_t>(data);
```

Set/Get directly on an instance:
```cpp
RED4ext::Variant data;
data.Set<uint64_t>(42); // return false on error

const auto hash = data.Get<uint64_t>();
```

**Notes**
This is a first step. In the end, integrating implementation from [RedLib](https://github.com/psiberx/cp2077-red-lib/blob/master/include/Red/TypeInfo/Resolving.hpp) would likely be the best solution for end-users. I left a comment about this.