### PR TITLE
feat(IPositionProvider): define world offset member

### DIFF
--- a/include/RED4ext/Scripting/Natives/entIPositionProvider.hpp
+++ b/include/RED4ext/Scripting/Natives/entIPositionProvider.hpp
@@ -1,22 +1,8 @@
 #pragma once
 
-// clang-format off
-
-// This file is generated from the Game's Reflection data
-
-#include <RED4ext/Scripting/Natives/entIPositionProvider.hpp>
-
-namespace RED4ext
-{
-RED4EXT_ASSERT_SIZE(ent::IPositionProvider, 0x50);
-using entIPositionProvider = ent::IPositionProvider;
-using IPositionProvider = ent::IPositionProvider;
-} // namespace RED4ext
-
-/*
-#include <cstdint>
 #include <RED4ext/Common.hpp>
 #include <RED4ext/Scripting/IScriptable.hpp>
+#include <RED4ext/Scripting/Natives/Vector3.hpp>
 
 namespace RED4ext
 {
@@ -27,13 +13,12 @@ struct IPositionProvider : IScriptable
     static constexpr const char* NAME = "entIPositionProvider";
     static constexpr const char* ALIAS = "IPositionProvider";
 
-    uint8_t unk40[0x50 - 0x40]; // 40
+    Vector3 worldOffset; // 40
+	uint8_t unk4C[0x50 - 0x4C]; // 4C
 };
 RED4EXT_ASSERT_SIZE(IPositionProvider, 0x50);
+RED4EXT_ASSERT_OFFSET(IPositionProvider, worldOffset, 0x40);
 } // namespace ent
 using entIPositionProvider = ent::IPositionProvider;
 using IPositionProvider = ent::IPositionProvider;
 } // namespace RED4ext
-*/
-
-// clang-format on

--- a/include/RED4ext/Scripting/Natives/entIPositionProvider.hpp
+++ b/include/RED4ext/Scripting/Natives/entIPositionProvider.hpp
@@ -13,7 +13,7 @@ struct IPositionProvider : IScriptable
     static constexpr const char* NAME = "entIPositionProvider";
     static constexpr const char* ALIAS = "IPositionProvider";
 
-    Vector3 worldOffset; // 40
+    Vector3 worldOffset;        // 40
     uint8_t unk4C[0x50 - 0x4C]; // 4C
 };
 RED4EXT_ASSERT_SIZE(IPositionProvider, 0x50);

--- a/include/RED4ext/Scripting/Natives/entIPositionProvider.hpp
+++ b/include/RED4ext/Scripting/Natives/entIPositionProvider.hpp
@@ -14,7 +14,7 @@ struct IPositionProvider : IScriptable
     static constexpr const char* ALIAS = "IPositionProvider";
 
     Vector3 worldOffset; // 40
-	uint8_t unk4C[0x50 - 0x4C]; // 4C
+    uint8_t unk4C[0x50 - 0x4C]; // 4C
 };
 RED4EXT_ASSERT_SIZE(IPositionProvider, 0x50);
 RED4EXT_ASSERT_OFFSET(IPositionProvider, worldOffset, 0x40);


### PR DESCRIPTION
[entIPositionProvider#GetWorldOffset](https://nativedb.red4ext.com/entIPositionProvider#GetWorldOffset) is at `1577656756`
[entIPositionProvider#SetWorldOffset](https://nativedb.red4ext.com/entIPositionProvider#SetWorldOffset) is at `1646862784`

constructor is at `3386706857` and confirms only X, Y, Z components of `Vector4` are initialized.