### PR TITLE
fix(HashMap): add const qualifier to `Contains` method

### DIFF
--- a/include/RED4ext/HashMap.hpp
+++ b/include/RED4ext/HashMap.hpp
@@ -208,7 +208,7 @@ struct HashMap
         return nullptr;
     }
 
-    bool Contains(const K& aKey)
+    bool Contains(const K& aKey) const
     {
         return Get(aKey) != nullptr;
     }


### PR DESCRIPTION
Only calls `Get` which is const qualified too.